### PR TITLE
Simplify dictutil.combineto and add test.

### DIFF
--- a/dictutil/dictutil.py
+++ b/dictutil/dictutil.py
@@ -360,30 +360,32 @@ def _attrdict(attrdict_clz, d, ref):
 
 
 def combineto(a, b, op, exclude=None, recursive=True):
+
     if not isinstance(b, dict):
         return a
 
     if exclude is None:
         exclude = {}
 
-    for k, v in b.iteritems():
+    for k, vb in b.iteritems():
         sub_exclude = exclude.get(k)
 
         if sub_exclude is True:
             continue
 
-        if isinstance(v, dict) and recursive == False:
-            continue
-
         if k not in a:
-            a[k] = copy.deepcopy(v)
-            continue
+            # use the default constructor of `vb` to get a `zero` value.
+            va = type(vb)()
+        else:
+            va = a[k]
 
-        if isinstance(a[k], dict):
-            combineto(a[k], v, op, exclude=sub_exclude, recursive=recursive)
-            continue
-
-        a[k] = op(a[k], v)
+        if isinstance(vb, dict):
+            if recursive:
+                a[k] = combineto(va, vb, op, exclude=sub_exclude, recursive=recursive)
+            else:
+                continue
+        else:
+            a[k] = op(va, vb)
 
     return a
 

--- a/dictutil/test/test_dictutil.py
+++ b/dictutil/test/test_dictutil.py
@@ -1215,110 +1215,103 @@ class TestAdd(unittest.TestCase):
 
     def test_add(self):
         cases = (
-            ({}, None, None, None, {}),
-            ({}, 'foo', None, None, {}),
-            ({}, 123, None, None, {}),
-            ({}, {}, None, None, {}),
-            ({'a': 1}, {}, None, None, {'a': 1}),
-            ({'a': 1}, {'a': 2}, None, None, {'a': 3}),
-            ({'a': '1'}, {'a': '2'}, None, None, {'a': '12'}),
-            ({'a': '1'}, {'b': '2'}, None, None, {'a': '1', 'b': '2'}),
-            ({'a': '1'}, {'b': {}}, None, None, {'a': '1', 'b': {}}),
-            ({'a': {}}, {'b': {}}, None, None, {'a': {}, 'b': {}}),
-            ({'a': {}}, {'a': {}}, None, None, {'a': {}}),
+            ({},          None,       {}, {}),
+            ({},          'foo',      {}, {}),
+            ({},          123,        {}, {}),
+            ({},          {},         {}, {}),
+            ({'a': 1},    {},         {}, {'a': 1}),
+            ({},          {'a': 2},   {}, {'a': 2}),
+            ({'a': 1},    {'a': 2},   {}, {'a': 3}),
+            ({'a': '1'},  {'a': '2'}, {}, {'a': '12'}),
+            ({'a': '1'},  {'b': '2'}, {}, {'a': '1', 'b': '2'}),
+            ({'a': '1'},  {'b': {}},  {}, {'a': '1', 'b': {}}),
+            ({'a': {}},   {'b': {}},  {}, {'a': {}, 'b': {}}),
+            ({'a': {}},   {'a': {}},  {}, {'a': {}}),
 
             ({'a': {'k1': 1}},
              {'a': {}},
-             None,
-             None,
+             {},
              {'a': {'k1': 1}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k2': 1}},
-             None,
-             None,
+             {},
              {'a': {'k1': 1, 'k2': 1}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             None,
-             None,
+             {},
              {'a': {'k1': 2}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             {'a': True},
-             None,
+             {'exclude': {'a': True}, },
              {'a': {'k1': 1}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             {'a': {}},
-             None,
+             {'exclude': {'a': {}}, },
              {'a': {'k1': 2}}),
 
             ({'a': {}},
              {'a': {'k1': 1}},
-             {'a': {}},
-             None,
+             {'exclude': {'a': {}}, },
              {'a': {'k1': 1}}),
 
             ({'a': {}},
              {'a': {'k1': 1}},
-             {'a': True},
-             None,
+             {'exclude': {'a': True}, },
              {'a': {}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             {'a': {}},
-             None,
+             {'exclude': {'a': {}}, },
              {'a': {'k1': 2}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             {'b': True},
-             None,
+             {'exclude': {'b': True}, },
              {'a': {'k1': 2}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             {'b': True},
-             None,
+             {'exclude': {'b': True}, },
              {'a': {'k1': 2}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             {'a': {'k1': True}},
-             True,
+             {'exclude': {'a': {'k1': True}}, 'recursive': True},
              {'a': {'k1': 1}}),
 
             ({'a': {'k1': 1}},
              {'a': {'k1': 1}},
-             {'a': {'k2': True}},
-             True,
+             {'exclude': {'a': {'k2': True}}, 'recursive': True},
              {'a': {'k1': 2}}),
 
             ({'a': {'k1': 1}, 'b': 1},
              {'a': {'k1': 1, 'k2': 1}, 'b': 1},
-             None,
-             False,
+             {'recursive': False},
              {'a': {'k1': 1}, 'b': 2}),
         )
 
-        for a, b, exclude, recursive, expected in cases:
-            result = dictutil.add(a, b, exclude=exclude,
-                                  recursive=recursive)
+        for a, b, kwargs, expected in cases:
+            dd('a:', a)
+            dd('b:', b)
+            dd('kwargs:', kwargs)
+            dd('expected:', expected)
+
+            result = dictutil.add(a, b, **kwargs)
+            dd('rst:', result)
+
             self.assertIsNot(a, result)
             self.assertDictEqual(expected, result,
-                                 repr([a, b, exclude, expected, result]))
+                                 repr([a, b, kwargs, result]))
 
-            result = dictutil.addto(a, b, exclude=exclude,
-                                    recursive=recursive)
+            result = dictutil.addto(a, b, **kwargs)
 
             self.assertIs(a, result)
             self.assertDictEqual(expected, result,
-                                 repr([a, b, exclude, expected, result]))
+                                 repr([a, b, kwargs, result]))
 
 
 class TestCombine(unittest.TestCase):


### PR DESCRIPTION
- Fix: tests should use absent kwargs instead of `k=None`.
- add test of zero for absent key: addto({}, {'a': 2}) --> {'a': 2}