### PR TITLE
Add sql maker

### DIFF
--- a/mysqlutil/README.md
+++ b/mysqlutil/README.md
@@ -315,7 +315,7 @@ mysqlutil.make_update_sql('errlog', {'_id': '0', 'time': '042718'}, None, None, 
 
 -   `values`:
     is values to insert into `table`.
-    A list or tuple of strings.
+    A `dict` whose keys are fields want to update, and values are the update values.
 
 -   `index`:
     specifies condition fields to find those rows to update.
@@ -465,7 +465,7 @@ make_index_scan_sql("foo", ['_id', 'key'], ['key', 'val'], ["a", "b"])
 # 'SELECT `_id`, `key` FROM `foo` FORCE INDEX (`idx_key_val`) WHERE `key` = "a" AND `val` >= "b" LIMIT 1024'
 
 make_index_scan_sql("foo", ['_id', 'key'], ['key', 'val'], ["a", "b"], index_name="bar")
-# 'SELECT `_id`, `key` FROM `foo` FORCE INDEX (`bar`) WHERE `foo`.`key` = "a" AND `val` >= "b" LIMIT 1024'
+# 'SELECT `_id`, `key` FROM `foo` FORCE INDEX (`bar`) WHERE `key` = "a" AND `val` >= "b" LIMIT 1024'
 
 make_index_scan_sql("foo", ['_id', 'key'], ['key', 'val'], ["a", "b"], left_open=True)
 # 'SELECT `_id`, `key` FROM `foo` FORCE INDEX (`idx_key_val`) WHERE `key` = "a" AND `val` > "b" LIMIT 1024'
@@ -505,7 +505,8 @@ make_index_scan_sql(("mydb","foo"), ['_id', 'key'], ['key', 'val'], ["a", "b"], 
 
 -   `index_name`:
     specifies an index to use to find rows in the table.
-    If it is not `None`, use `index_name` as the index and `index` is ignored.
+    If it is not `None`, use `index_name` as the force index filed, otherwise `index` is used.
+    By default, it is `None`.
 
 **return**:
 a string which is a sql select statement.

--- a/mysqlutil/__init__.py
+++ b/mysqlutil/__init__.py
@@ -3,10 +3,15 @@ from . import (
 )
 
 from .mysqlutil import (
-    scan_index,
-    sql_scan_index,
     ConnectionTypeError,
-    IndexNotPairs,
+    InvalidLength,
+
+    make_delete_sql,
+    make_index_scan_sql,
+    make_insert_sql,
+    make_select_sql,
+    make_update_sql,
+    scan_index,
 )
 
 from privilege import (
@@ -14,10 +19,15 @@ from privilege import (
 )
 
 __all__ = [
+    "ConnectionTypeError",
+    "InvalidLength",
+
     "gtidset",
+    "make_delete_sql",
+    "make_index_scan_sql",
+    "make_insert_sql",
+    "make_select_sql",
+    "make_update_sql",
     "privileges",
     "scan_index",
-    "sql_scan_index",
-    "ConnectionTypeError",
-    "IndexNotPairs",
 ]

--- a/mysqlutil/test/test_mysqlutil.py
+++ b/mysqlutil/test/test_mysqlutil.py
@@ -6,8 +6,6 @@ import unittest
 
 import docker
 
-from MySQLdb.constants import FIELD_TYPE
-
 from pykit import mysqlconnpool
 from pykit import mysqlutil
 from pykit import proc
@@ -35,7 +33,6 @@ class TestMysqlutil(unittest.TestCase):
             'port': mysql_test_port,
             'user': mysql_test_user,
             'passwd': mysql_test_password,
-            'conv': {FIELD_TYPE.LONG: str},
         }
 
         conns = (addr,
@@ -98,7 +95,7 @@ class TestMysqlutil(unittest.TestCase):
                         dd('rst:', rr)
                         dd('except: ', rst_expect[i])
 
-                        self.assertEqual(rr[0], rst_expect[i])
+                        self.assertEqual(rr[0], long(rst_expect[i]))
 
                     self.assertEqual(len(rst_expect), i+1)
         finally:


### PR DESCRIPTION
1. 增加了 select | update | insert | delete sql 语句的拼接方法。
2. 修改函数名 `sql_index_scan` 为 `make_index_scan_sql`。
3. Review 之后需要调整一下 readme 中函数的排序。