### PR TITLE
我发4, 最后1个pr了... zktx: zookeeper based transaction engine

### DIFF
--- a/ututil.py
+++ b/ututil.py
@@ -15,6 +15,16 @@ _glb = {
 debug_to_stdout = os.environ.get('UT_DEBUG') == '1'
 
 
+# TODO make this configurable
+# logging.basicConfig(level='INFO',
+#                     format='[%(asctime)s,%(process)d-%(thread)d,%(filename)s,%(lineno)d,%(levelname)s] %(message)s',
+#                     datefmt='%H:%M:%S'
+#                     )
+
+# logger = logging.getLogger('kazoo')
+# logger.setLevel('INFO')
+
+
 class Timer(object):
 
     def __init__(self):

--- a/zktx/__init__.py
+++ b/zktx/__init__.py
@@ -4,14 +4,14 @@ from .accessor import (
 )
 
 from .exceptions import (
-    TXAborted,
-    TXConnectionLost,
-    TXDuplicatedLock,
+    Aborted,
+    ConnectionLoss,
+    Deadlock,
+    HigherTXApplied,
+    RetriableError,
     TXError,
-    TXHigherTXApplied,
-    TXPotentialDeadlock,
     TXTimeout,
-    TXUserAborted,
+    UserAborted,
 )
 
 from .status import (
@@ -36,18 +36,25 @@ from .zkaccessor import (
     ZKValue,
 )
 
+from .zktx import (
+    TXRecord,
+    ZKTransaction,
+
+    run_tx,
+)
+
 __all__ = [
     "KVAccessor",
     "ValueAccessor",
 
-    "TXAborted",
-    "TXConnectionLost",
-    "TXDuplicatedLock",
+    "Aborted",
+    "ConnectionLoss",
+    "Deadlock",
+    "HigherTXApplied",
+    "RetriableError",
     "TXError",
-    "TXHigherTXApplied",
-    "TXPotentialDeadlock",
     "TXTimeout",
-    "TXUserAborted",
+    "UserAborted",
 
     "ABORTED",
     "COMMITTED",
@@ -62,4 +69,9 @@ __all__ = [
     "ZKValue",
 
     "ZKStorage",
+
+    "TXRecord",
+    "ZKTransaction",
+
+    "run_tx",
 ]

--- a/zktx/exceptions.py
+++ b/zktx/exceptions.py
@@ -1,34 +1,36 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import kazoo.exceptions
+
 
 class TXError(Exception):
     pass
 
 
-class TXAborted(TXError):
+class Aborted(TXError):
     pass
 
 
-class TXUserAborted(TXAborted):
+class RetriableError(TXError):
     pass
 
 
-class TXHigherTXApplied(TXAborted):
+class UserAborted(Aborted):
     pass
 
 
-class TXDuplicatedLock(TXAborted):
+class HigherTXApplied(Aborted, RetriableError):
     pass
 
 
-class TXTimeout(TXAborted):
+class Deadlock(Aborted, RetriableError):
     pass
 
 
-class TXPotentialDeadlock(TXAborted):
+class TXTimeout(Aborted):
     pass
 
 
-class TXConnectionLost(TXError):
+class ConnectionLoss(TXError, kazoo.exceptions.ConnectionLoss):
     pass

--- a/zktx/test/test_tx.py
+++ b/zktx/test/test_tx.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import time
+
+from pykit import rangeset
+from pykit import threadutil
+from pykit import utfjson
+from pykit import ututil
+from pykit import zktx
+from pykit.zktx import ABORTED
+from pykit.zktx import COMMITTED
+from pykit.zktx import PURGED
+from pykit.zktx import ConnectionLoss
+from pykit.zktx import Deadlock
+from pykit.zktx import HigherTXApplied
+from pykit.zktx import TXError
+from pykit.zktx import TXTimeout
+from pykit.zktx import UserAborted
+from pykit.zktx import ZKTransaction
+from pykit.zktx.test import base
+
+dd = ututil.dd
+
+zkhost = '127.0.0.1:2181'
+
+
+class TestTX(base.ZKTestBase):
+
+    def setUp(self):
+        super(TestTX, self).setUp()
+
+        self.zk.create('tx', 'tx')
+        self.zk.create('lock', '{}')
+        self.zk.create('tx/txidset', '{}')
+        self.zk.create('tx/alive', '{}')
+        self.zk.create('tx/txid_maker', '{}')
+        self.zk.create('tx/journal', '{}')
+        self.zk.create('record', '{}')
+
+    def test_single_record(self):
+
+        tx = ZKTransaction(zkhost)
+        tx.begin()
+
+        foo = tx.lock_get('foo')
+        self.assertEqual('foo', foo.k)
+        self.assertIsNone(foo.v)
+        foo.v = 1
+
+        tx.set(foo)
+
+        tx.commit()
+
+        rst, ver = self.zk.get('record/foo')
+        self.assertEqual({'-1': None, '1': 1}, utfjson.load(rst))
+
+        rst, ver = self.zk.get('tx/txidset')
+        self.assertEqual({COMMITTED: [[1, 2]],
+                          ABORTED: [],
+                          PURGED: [],
+                          }, utfjson.load(rst))
+
+    def test_with_statement(self):
+
+        with ZKTransaction(zkhost) as t1:
+
+            foo = t1.lock_get('foo')
+            foo.v = 1
+
+            t1.set(foo)
+
+            t1.commit()
+
+        rst, ver = self.zk.get('record/foo')
+        self.assertEqual({'-1': None, '1': 1}, utfjson.load(rst))
+
+        rst, ver = self.zk.get('tx/txidset')
+        self.assertEqual({COMMITTED: [[1, 2]],
+                          ABORTED: [],
+                          PURGED: [],
+                          }, utfjson.load(rst))
+
+    def test_lock_get_twice(self):
+
+        with ZKTransaction(zkhost) as t1:
+
+            foo = t1.lock_get('foo')
+            foo.v = 1
+            t1.set(foo)
+
+            f2 = t1.lock_get('foo')
+            self.assertEqual(None, f2.v)
+            f2.v = 2
+            t1.set(f2)
+
+            t1.commit()
+
+        rst, ver = self.zk.get('record/foo')
+        self.assertEqual({'-1': None, '1': 2}, utfjson.load(rst))
+
+    def test_run(self):
+
+        def _tx(tx):
+            foo = tx.lock_get('foo')
+            foo.v = 100
+            tx.set(foo)
+            tx.commit()
+
+        status, txid = zktx.run_tx(zkhost, _tx)
+        self.assertEqual((COMMITTED, 1), (status, txid))
+
+        t = ZKTransaction(zkhost)
+        rst, ver = t.zkstorage.get_latest('foo')
+        self.assertEqual(100, rst.values()[0])
+
+        rst, ver = self.zk.get('tx/txidset')
+        self.assertEqual({COMMITTED: [[1, 2]],
+                          ABORTED: [],
+                          PURGED: [],
+                          }, utfjson.load(rst))
+
+    def test_run_timeout(self):
+
+        def _tx(tx):
+            tx.lock_get('foo')
+            time.sleep(0.5)
+            tx.commit()
+
+        try:
+            zktx.run_tx(zkhost, _tx, timeout=0.4)
+            self.fail('TXTimeout expected')
+        except TXTimeout as e:
+            dd(repr(e))
+
+    def test_run_conn_loss(self):
+
+        def _tx(tx):
+            tx.lock_get('foo')
+            tx.zke.stop()
+            tx.commit()
+
+        try:
+            zktx.run_tx(zkhost, _tx)
+            self.fail('ConnectionLoss expected')
+        except ConnectionLoss as e:
+            dd(repr(e))
+
+    def test_run_retriable_error(self):
+
+        errs = [HigherTXApplied, Deadlock, None]
+
+        def _tx(tx):
+
+            foo = tx.lock_get('foo')
+            foo.v = 100
+            tx.set(foo)
+
+            err = errs.pop(0)
+            if err is not None:
+                raise err()
+            else:
+                tx.commit()
+
+        status, txid = zktx.run_tx(zkhost, _tx)
+        # 2 error tried and one commit
+        self.assertEqual((COMMITTED, 3), (status, txid))
+
+        t = ZKTransaction(zkhost)
+        rst, ver = t.zkstorage.get_latest('foo')
+        self.assertEqual(100, rst.values()[0])
+
+    def test_run_unretriable_error(self):
+
+        sess = dict(n=0)
+        errs = [UserAborted, TXTimeout, ConnectionLoss, None]
+
+        def _tx(tx, err):
+
+            sess['n'] += 1
+
+            foo = tx.lock_get('foo')
+            foo.v = 100
+            tx.set(foo)
+
+            if err is not None:
+                raise err()
+            else:
+                tx.commit()
+
+        for err in errs:
+            try:
+                zktx.run_tx(zkhost, _tx, args=(err, ))
+            except TXError as e:
+                dd(repr(e))
+
+        self.assertEqual(len(errs), sess['n'])
+
+        tx = ZKTransaction(zkhost)
+        rst, ver = tx.zkstorage.get_latest('foo')
+        self.assertEqual(100, rst.values()[0])
+
+    def test_sequential(self):
+
+        n_tx = 10
+        k = 'foo'
+
+        for ii in range(n_tx):
+
+            with ZKTransaction(zkhost) as t1:
+
+                foo = t1.lock_get(k)
+                foo.v = foo.v or 0
+                foo.v += 1
+
+                t1.set(foo)
+
+                t1.commit()
+
+        t = ZKTransaction(zkhost)
+
+        rst, ver = t.zkstorage.get_latest(k)
+        dd(rst)
+        self.assertEqual(n_tx, rst.values()[0])
+
+        rst, ver = t.zkstorage.txidset.get()
+        dd(rst)
+        self.assertEqual(n_tx, rst[COMMITTED].length())
+
+    def test_concurrent_single_record(self):
+
+        n_tx = 10
+
+        def _tx():
+            while True:
+                try:
+                    with ZKTransaction(zkhost) as t1:
+
+                        foo = t1.lock_get('foo')
+                        foo.v = foo.v or 0
+                        foo.v += 1
+
+                        t1.set(foo)
+                        t1.commit()
+                        return
+
+                except (Deadlock,
+                        HigherTXApplied) as e:
+                    dd(repr(e))
+                    continue
+
+        for th in [threadutil.start_daemon(_tx)
+                   for i in range(n_tx)]:
+
+            th.join()
+
+        t = ZKTransaction(zkhost)
+
+        rst, ver = t.zkstorage.get_latest('foo')
+        dd(rst)
+        self.assertEqual(n_tx, rst.values()[0])
+
+        rst, ver = t.zkstorage.txidset.get()
+        dd(rst)
+        self.assertEqual(n_tx, rst[COMMITTED].length())
+
+    def test_concurrent_3_record(self):
+
+        n_tx = 10
+        ks = ('foo', 'bar', 'duu')
+
+        def _tx(i):
+            while True:
+                try:
+                    with ZKTransaction(zkhost) as t1:
+
+                        for ii in range(len(ks)):
+                            k = ks[(ii+i) % len(ks)]
+
+                            foo = t1.lock_get(k)
+                            foo.v = foo.v or 0
+                            foo.v += 1
+
+                            t1.set(foo)
+
+                        t1.commit()
+                        dd(str(t1) + ' committed')
+                        return
+
+                except (Deadlock,
+                        HigherTXApplied) as e:
+                    dd(str(t1) + ': ' + repr(e))
+                    continue
+                except TXTimeout as e:
+                    dd(str(t1) + ': ' + repr(e))
+                    raise
+
+        with ututil.Timer() as tt:
+
+            for th in [threadutil.start_daemon(_tx, args=(i, ))
+                       for i in range(n_tx)]:
+
+                th.join()
+
+            dd('3 key 10 thread: ', tt.spent())
+
+        t = ZKTransaction(zkhost)
+
+        for k in ks:
+            rst, ver = t.zkstorage.get_latest(k)
+            dd(rst)
+            self.assertEqual(n_tx, rst.values()[0])
+
+        rst, ver = t.zkstorage.txidset.get()
+        dd(rst)
+        self.assertEqual(n_tx, rst[COMMITTED].length())
+
+        # check aborted txidset
+        sm = rangeset.union(rst[COMMITTED], rst[ABORTED])
+        self.assertEqual(rst[COMMITTED][-1][-1] - 1, sm.length())
+
+    def test_redo_dead_tx_without_journal(self):
+
+        t1 = ZKTransaction(zkhost)
+        t1.begin()
+        t1.lock_get('foo')
+
+        t1.zke.stop()
+
+        with ZKTransaction(zkhost) as t2:
+
+            foo = t2.lock_get('foo')
+            foo.v = foo.v or 0
+            foo.v += 1
+
+            t2.set(foo)
+            t2.commit()
+
+        t = ZKTransaction(zkhost)
+
+        rst, ver = t.zkstorage.get_latest('foo')
+        dd(rst)
+        self.assertEqual(1, rst.values()[0])
+
+        rst, ver = t.zkstorage.txidset.get()
+        dd(rst)
+        self.assertEqual([1, 2], rst[ABORTED][0])
+        self.assertEqual([2, 3], rst[COMMITTED][0])
+
+    def test_redo_dead_tx_with_journal(self):
+
+        t1 = ZKTransaction(zkhost)
+        t1.begin()
+        t1.lock_get('foo')
+        # fake a half-unlocked condition: bar is released but not foo
+        t1.zkstorage.journal.create(t1.txid, {'foo': 555, 'bar': 666})
+
+        t1.zke.stop()
+
+        with ZKTransaction(zkhost) as t2:
+
+            foo = t2.lock_get('foo')
+            foo.v = foo.v or 0
+            foo.v += 1
+
+            t2.set(foo)
+            t2.commit()
+
+        t = ZKTransaction(zkhost)
+
+        rst, ver = t.zkstorage.get_latest('foo')
+        dd(rst)
+        self.assertEqual(556, rst.values()[0])
+
+        rst, ver = t.zkstorage.get_latest('bar')
+        dd(rst)
+        self.assertEqual(666, rst.values()[0])
+
+        rst, ver = t.zkstorage.txidset.get()
+        dd(rst)
+        self.assertEqual([1, 3], rst[COMMITTED][0])
+
+    def test_abort(self):
+
+        with ZKTransaction(zkhost) as t1:
+            foo = t1.lock_get('foo')
+            foo.v = 100
+            t1.set(foo)
+            t1.abort()
+
+        t = ZKTransaction(zkhost)
+
+        rst, ver = t.zkstorage.get_latest('foo')
+        dd(rst)
+        self.assertEqual(None, rst.values()[0])
+
+        rst, ver = t.zkstorage.txidset.get()
+        dd(rst)
+        self.assertEqual([1, 2], rst[ABORTED][0])

--- a/zktx/test/test_zkstorage.py
+++ b/zktx/test/test_zkstorage.py
@@ -6,7 +6,9 @@ from pykit import utfjson
 from pykit import ututil
 from pykit import zktx
 from pykit import zkutil
+from pykit.zktx import ABORTED
 from pykit.zktx import COMMITTED
+from pykit.zktx import PURGED
 from pykit.zktx.test import base
 
 dd = ututil.dd
@@ -31,7 +33,10 @@ class TestZKStorage(base.ZKTestBase):
         self.zs.add_to_txidset(COMMITTED, 1)
         rst, ver = self.zs.txidset.get()
 
-        self.assertEqual({COMMITTED: [[1, 2]]}, rst)
+        self.assertEqual({COMMITTED: [[1, 2]],
+                          ABORTED: [],
+                          PURGED: [],
+                          }, rst)
 
     def test_journal(self):
 

--- a/zktx/transaction.md
+++ b/zktx/transaction.md
@@ -1,6 +1,26 @@
-# A typical transaction running phases
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+#   Table of Content
+
+- [Transaction](#transaction)
+- [Concept](#concept)
+- [A typical transaction running phases](#a-typical-transaction-running-phases)
+  - [For tx killed in phase 0, 1, 2, 3](#for-tx-killed-in-phase-0-1-2-3)
+    - [Condition:](#condition)
+    - [Solution: Abort](#solution-abort)
+  - [For tx killed in phase 4, 5, 6, 7, 8, 9](#for-tx-killed-in-phase-4-5-6-7-8-9)
+    - [Condition:](#condition-1)
+    - [Solution: re-apply journal and unlock](#solution-re-apply-journal-and-unlock)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Transaction
 
 > In this doc `tx` is an abbreviation of `transaction`.
+
+
+# Concept
+
 
 In the following chart it shows how resource status changes when tx action is
 taken.
@@ -33,7 +53,50 @@ Normally tx resources includes:
     In our implementation all tx status are stored together in one zk-node:
     `txidset`.
 
-    Its value is 3 set of COMMITTED txid, ABORTED txid and PURGED txid.
+    `txidset` is a dict of 3 `rangeset` for COMMITTED, ABORTED and PURGED:
+
+    ```yaml
+    COMMITTED: [[1, 2], [4, 5]]
+    ABORTED:   [[2, 4]]
+    PURGED:    [[1, 3]]
+    ```
+
+    -   COMMITTED:
+        -   If a tx completely committed, its txid is add to `txidset["COMMITTED"]`.
+        -   If a tx aborted(for any reason) **AFTER** journal was written, there is a
+            chance another tx detected this dead tx and re-do it.
+            In this case, eventually the dead tx will be committed, and will be
+            added into `txidset["COMMITTED"]`.
+
+    -   ABORTED:
+        -   If a user explicitly aborts a tx(by calling `tx.abort()`), the txid
+            is added into `txidset["ABORTED"]`.
+        -   If a tx aborted(for any reason) **BEFORE** journal was written,
+            another tx will find this dead tx by acquiring a key-lock that the
+            dead tx had been held.
+            In this case, the other tx will add the dead txid into `txidset["ABORTED"]`.
+
+    -   PURGED:
+        -   In order to recycle storage space in zk, there is a background
+            process cleans up journal. If a journal is removed, its txid is
+            added into `txidset["PURGED"]`.
+
+    **ABORTED txid set and COMMITTED txid set has no common element**:
+    A tx is either COMMITTED or ABORTED.
+
+    > It is possible a dead txid not in either of COMMITTED or ABORTED, when no
+    > one has discovered this tx was dead(another tx will find a dead tx when
+    > trying to acquire a key-lock which is held by dead tx, and there is a
+    > background process periodically looks up for dead tx).
+
+    A txid that is added into `txidset["PURGED"]` will not be removed from
+    ABORTED or COMMITTED(not necessary).
+
+    Thus all journals those are current available in zk are:
+    `txidset["COMMITTED"] - txidset["PURGED"]`.
+
+
+# A typical transaction running phases
 
 ```
 |     |  action \ resource | tx-lock | 3 key-locks | journal | 3 keys | committed-flag |
@@ -43,24 +106,28 @@ Normally tx resources includes:
 | 2   | lock_get()         | √       | √√          |         |        |                |
 | 3   | lock_get()         | √       | √√√         |         |        |                |
 | 4   | write_journal()    | √       | √√√         | √       |        |                |
-| 5   | apply(...          | √       | √√√         | √       | √      |                |
+| 5   | apply(             | √       | √√√         | √       | √      |                |
 | 6   | .....)             | √       | √√√         | √       | √√√    |                |
-| 7   | unlock_key(...     | √       |  √√         | √       | √√√    |                |
+| 7   | unlock_key(        | √       |  √√         | √       | √√√    |                |
 | 8   | ..........)        | √       |             | √       | √√√    |                |
 | 9   | add_txidset()      | √       |             | √       | √√√    | √              |
 | a   | unlock_tx()        |         |             | √       | √√√    | √              |
 ```
 
-A tx may be killed in any step, by any reason.
+A tx may be killed in any phase, by any reason.
 
-We have corresponding recovery procedure for each step to guarantee that a tx
+We have corresponding recovery procedure for each phase to guarantee that a tx
 either be completely applied or completely aborted.
+
+-   A tx died without finishing phase-4 will be **eventually aborted**.
+-   A tx finished phase-4 will be **eventually committed**.
 
 **Any time a tx runner is killed, tx-lock is deleted automatically(by the
 definition of ephemeral node). But key-lock will not be deleted
 automatically(key locks are not ephemeral zk node)**.
 
-A redo process first re-acquire the tx-lock, then does the following step:
+A redo process first re-acquire the tx-lock(in order to ensure no other process
+was dealing with this tx), then does the following phase:
 
 ## For tx killed in phase 0, 1, 2, 3
 

--- a/zktx/zkaccessor.py
+++ b/zktx/zkaccessor.py
@@ -25,9 +25,10 @@ class ZKKeyValue(object):
         else:
             return self._get_path(key)
 
-    def create(self, key, value):
+    def create(self, key, value, ephemeral=False, sequence=False):
         value = self._dump(value)
-        return self.zkclient.create(self.get_path(key), value)
+        return self.zkclient.create(self.get_path(key), value,
+                                    ephemeral=ephemeral, sequence=sequence)
 
     def delete(self, key, version=-1):
         return self.zkclient.delete(self.get_path(key), version=version)
@@ -81,8 +82,9 @@ class ZKValue(ZKKeyValue):
     def get_path(self, key):
         return self._get_path()
 
-    def create(self, value):
-        return super(ZKValue, self).create('', value)
+    def create(self, value, ephemeral=False, sequence=False):
+        return super(ZKValue, self).create('', value,
+                                           ephemeral=ephemeral, sequence=sequence)
 
     def delete(self, version=-1):
         return super(ZKValue, self).delete('', version=version)

--- a/zktx/zktx.py
+++ b/zktx/zktx.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import copy
+import logging
+import threading
+import time
+
+from kazoo import exceptions
+from kazoo.client import KazooState
+from kazoo.exceptions import KazooException
+from kazoo.exceptions import NoNodeError
+
+from pykit import rangeset
+from pykit import zkutil
+
+from .exceptions import ConnectionLoss
+from .exceptions import Deadlock
+from .exceptions import HigherTXApplied
+from .exceptions import RetriableError
+from .exceptions import TXTimeout
+from .exceptions import UserAborted
+from .status import ABORTED
+from .status import COMMITTED
+from .zkstorage import ZKStorage
+
+logger = logging.getLogger(__name__)
+
+
+class TXRecord(object):
+
+    def __init__(self, k, v, txid):
+        self.k = k
+        self.v = v
+        self.txid = txid
+
+    def __str__(self):
+        return '{k}={v}@{txid}'.format(
+            k=self.k, v=self.v, txid=txidstr(self.txid))
+
+
+class ZKTransaction(object):
+
+    def __init__(self, zk, timeout=None):
+
+        if timeout is None:
+            timeout = 10
+
+        # Save the original arg for self.run()
+        self._zk = zk
+
+        self.zke, self.owning_zk = zkutil.kazoo_client_ext(zk)
+        self.timeout = timeout
+
+        self.txid = None
+        self.expire_at = None
+        self.tx_alive_lock = None
+
+        # User locked and required keys
+        self.got_keys = {}
+        # Keys user need to commit
+        self.modifications = {}
+
+        self.state_lock = threading.RLock()
+        self.connected = True
+
+        self.tx_status = None
+
+        self.zkstorage = ZKStorage(self.zke)
+
+        self.zke.add_listener(self._on_conn_change)
+
+    def _on_conn_change(self, state):
+
+        logger.debug('state changed: {state}'.format(state=state,))
+
+        with self.state_lock:
+            if state == KazooState.LOST or state == KazooState.SUSPENDED:
+                self.connected = False
+
+    def lock_get(self, key):
+
+        # We use persistent lock(ephemeral=False)
+        # thus we do not need to care about connection loss during locking
+        # phase.
+        # But we still need to check connection when creating journal.
+
+        if key in self.got_keys:
+            return copy.deepcopy(self.got_keys[key])
+
+        self.lock_key(key)
+
+        l, version = self.zkstorage.get_latest(key)
+
+        ltxid, lvalue = l.items()[0]
+
+        curr = TXRecord(k=key, v=lvalue, txid=ltxid)
+        self.got_keys[key] = curr
+
+        if ltxid > self.txid:
+            raise HigherTXApplied('{tx} seen a higher txid applied: {txid}'.format(
+                tx=self, txid=ltxid))
+
+        rec = TXRecord(k=key, v=lvalue, txid=ltxid)
+        return rec
+
+    def set(self, rec):
+        logger.info('{tx} tx.set: {rec}'.format(tx=self, rec=rec))
+        self.modifications[rec.k] = rec
+
+    def lock_key(self, key):
+
+        try:
+            for other_txid, ver in self.zkstorage.watch_acquire_key(
+                    self.txid, key, timeout=self.time_left()):
+
+                logger.info('{tx} wait[{key}]-> {other_txid} ver: {ver}'.format(
+                    tx=self, key=key, other_txid=txidstr(other_txid), ver=ver))
+
+                if not self.is_tx_alive(other_txid):
+                    rst = self.redo_dead_tx(other_txid)
+
+                    # aborted tx did not release lock by itself
+                    if rst == ABORTED:
+                        self.zkstorage.try_release_key(other_txid, key)
+
+                    continue
+
+                logger.info('{tx}: other tx {other_txid} is alive'.format(
+                    tx=self, other_txid=txidstr(other_txid)))
+
+                if self.txid > other_txid:
+
+                    if len(self.got_keys) == 0:
+
+                        # no locking, no deadlock
+                        logger.info('{tx} wait[{key}]-> {other_txid} no-lock'.format(
+                            tx=self, key=key, other_txid=txidstr(other_txid)))
+
+                        for i in range(other_txid, self.txid):
+                            self.wait_tx_to_finish(i)
+                        continue
+                    else:
+                        # let earlier tx to finish first
+                        logger.info('{tx} wait[{key}]-> {other_txid} deadlock'.format(
+                            tx=self, key=key, other_txid=txidstr(other_txid)))
+
+                        self.unlock_all_keys()
+                        for i in range(other_txid, self.txid):
+                            self.wait_tx_to_finish(i)
+
+                        raise Deadlock('my txid: {mytxid} lockholder txid: {other_txid}'.format(
+                            mytxid=self.txid, other_txid=other_txid))
+
+                # self.txid < other_txid:
+                # I am an earlier tx. I should run first.
+                #
+                # If there is no deadlock:
+                #   the older tx will finish later. Then I wait.
+                #
+                # If there is a deadlock:
+                #   the older tx will abort.
+                logger.info('{tx} wait[{key}]-> {other_txid}'.format(
+                    tx=self, key=key, other_txid=txidstr(other_txid)))
+
+        except zkutil.LockTimeout:
+            raise TXTimeout('{tx} timeout waiting for lock: {key}'.format(tx=self, key=key))
+
+        logger.info('{tx} [{key}] locked'.format(tx=self, key=key))
+
+    def wait_tx_to_finish(self, txid):
+
+        logger.info('{tx} wait-> {other_txid}'.format(tx=self, other_txid=txidstr(txid)))
+
+        try:
+            zkutil.wait_absent(self.zke,
+                               self.zke._zkconf.tx_alive(txid),
+                               timeout=self.time_left())
+        except zkutil.ZKWaitTimeout as e:
+
+            logger.info(repr(e) + ' while waiting for other tx: {txid}'.format(
+                txid=txid))
+
+            raise TXTimeout('{tx} timeout waiting for tx:{txid}'.format(tx=self, txid=txid))
+
+    def redo_all_dead_tx(self):
+
+        sets = self.zkstorage.get_txidset()
+
+        # Only check for holes in the txid range set.
+        # With `txidset = [[1, 2], [4, 5]]`, tx-2 and tx-3 is unfinished tx.
+        # Check these tx
+
+        # A tx is committed or aborted that does not need to handle it again.
+        known = rangeset.union(sets[COMMITTED], sets[ABORTED])
+
+        for rng in known[:-1]:
+
+            txid = rng[1]
+
+            if not self.is_tx_alive(txid):
+                self.redo_dead_tx(txid)
+
+    def redo_dead_tx(self, txid):
+
+        dead_tx = ZKTransaction(self.zke,
+                                timeout=self.expire_at - time.time())
+
+        dead_tx.begin(txid=txid)
+        rst = dead_tx.redo()
+        dead_tx._close()
+        return rst
+
+    def redo(self):
+
+        logger.info('REDO: {tx}'.format(tx=self))
+
+        txidset, ver = self.zkstorage.txidset.get()
+        logger.info('{tx} got txidset: {txidset}'.format(tx=self, txidset=txidset))
+
+        if txidset[COMMITTED].has(self.txid):
+            return COMMITTED
+        elif txidset[ABORTED].has(self.txid):
+            return ABORTED
+
+        # self.txid is not in txidset
+
+        try:
+            jour, version = self.zkstorage.journal.get(self.txid)
+        except NoNodeError:
+            # This tx has not yet written a journal.
+            # Nothing to apply
+            self.zkstorage.add_to_txidset(ABORTED, self.txid)
+            return ABORTED
+
+        # A tx maybe killed when its key locks are half released.
+        #
+        # Because unlocking always happens after applying all modifications.
+        # Thus applying without locking is ok:
+        # Non-locked keys must already have higher or equal txid thus re-apply
+        # does not affect.
+        for k, v in jour.items():
+            self.zkstorage.apply_record(self.txid, k, v)
+
+        # unlock all
+        for key in jour:
+            self.zkstorage.try_release_key(self.txid, key)
+
+        self.zkstorage.add_to_txidset(COMMITTED, self.txid)
+        return COMMITTED
+
+    def is_tx_alive(self, txid):
+        try:
+            self.zke.get(self.zke._zkconf.tx_alive(txid))
+            logger.info('{tx} tx:{txid} is alive'.format(tx=self, txid=txid))
+            return True
+        except NoNodeError:
+            logger.info('{tx} tx:{txid} is dead'.format(tx=self, txid=txid))
+            return False
+
+    def begin(self, txid=None):
+
+        assert self.expire_at is None
+
+        self.expire_at = time.time() + self.timeout
+
+        if txid is not None:
+            # Run a specified tx, normally when to recover a dead tx process
+            self.txid = txid
+
+        else:
+            # Run a new tx, create txid.
+            zstat = self.zke.set(self.zke._zkconf.txid_maker(), 'x')
+            self.txid = zstat.version
+
+        zkconf = copy.deepcopy(self.zke._zkconf.conf)
+        zkconf['lock_dir'] = self.zke._zkconf.tx_alive()
+
+        self.tx_alive_lock = zkutil.ZKLock(self.txid,
+                                           zkconf=zkconf,
+                                           zkclient=self.zke,
+                                           timeout=self.expire_at-time.time())
+
+        self.tx_alive_lock.acquire()
+
+    def commit(self):
+
+        # Only when commit, it is necessary to ensure connection still active:
+        # Thus tx_alive_lock is not lost, then no other process would take
+        # charge of this tx.
+
+        if self.time_left() < 0:
+            raise TXTimeout('{tx} timeout when committing'.format(tx=self))
+
+        self._assert_connected()
+
+        jour = {}
+
+        for k, rec in self.modifications.items():
+            curr = self.got_keys[k]
+            if rec.v == curr.v:
+                continue
+
+            jour[k] = rec.v
+
+        self.zkstorage.journal.create(self.txid, jour)
+        logger.info('{tx} written journal: {jour}'.format(
+            tx=self, jour=jour))
+
+        for k, v in jour.items():
+            self.zkstorage.apply_record(self.txid, k, v)
+            logger.info('{tx} applied: {k}={v}'.format(tx=self, k=k, v=v))
+
+        # Must unlock keys before add to txidset.
+        # A txid presents in txidset means everything is done.
+        self.unlock_all_keys()
+        self.zkstorage.add_to_txidset(COMMITTED, self.txid)
+
+        logger.info('{tx} updated txidset: {status}'.format(
+            tx=self, status=COMMITTED))
+
+        self.tx_status = COMMITTED
+        self.modifications = {}
+        self._close()
+
+    def abort(self):
+        raise UserAborted()
+
+    def is_timeout(self):
+        return self.time_left() > 0
+
+    def time_left(self):
+        return self.expire_at - time.time()
+
+    def _close(self):
+
+        self.unlock_all_keys()
+
+        if self.tx_alive_lock is not None:
+
+            try:
+                self.tx_alive_lock.release()
+
+            except (exceptions.ConnectionClosedError,
+                    exceptions.ConnectionLoss) as e:
+
+                logger.warn('{tx} {e} while release tx alive lock'.format(
+                    tx=self, e=repr(e)))
+
+            self.tx_alive_lock = None
+
+        self.zke.remove_listener(self._on_conn_change)
+
+        self.modifications = {}
+
+        if self.owning_zk:
+            try:
+                self.zke.stop()
+            except KazooException as e:
+                logger.info(repr(e) + ' while zkclient.stop()')
+
+    def unlock_all_keys(self):
+
+        for key in self.got_keys:
+
+            logger.info('{tx} releasing:[{key}]'.format(tx=self, key=key))
+
+            try:
+                self.zkstorage.try_release_key(self.txid, key)
+            except (exceptions.ConnectionClosedError,
+                    exceptions.ConnectionLoss) as e:
+
+                logger.warn('{tx} {e} while release key lock {key}'.format(
+                    tx=self, e=repr(e), key=key))
+                break
+
+        self.got_keys = {}
+
+    def _assert_connected(self):
+        with self.state_lock:
+            if not self.connected:
+                raise ConnectionLoss()
+
+    def __enter__(self):
+        self.begin()
+        return self
+
+    def __exit__(self, errtype, errval, _traceback):
+
+        logger.info('{tx} __exit__ errtype:{errtype} errval:{errval}'.format(
+            tx=self, errtype=errtype, errval=errval))
+
+        try:
+            if self.txid is not None and self.tx_status is None:
+
+                self.tx_status = ABORTED
+                try:
+                    self.zkstorage.add_to_txidset(ABORTED, self.txid)
+                except (exceptions.ConnectionClosedError,
+                        exceptions.ConnectionLoss) as e:
+
+                    logger.warn('{tx} {e} while adding to txidset.ABORTED'.format(
+                        tx=self, e=repr(e)))
+
+            if errval is None:
+                return True
+
+            if isinstance(errval, UserAborted):
+                return True
+
+            return False
+
+        finally:
+            self._close()
+
+    def __str__(self):
+        return '{tx}[{locked}]'.format(tx=txidstr(self.txid),
+                                       locked=','.join(sorted(self.got_keys.keys())))
+
+
+def run_tx(zk, func, timeout=None, args=(), kwargs=None):
+
+    if timeout is None:
+        timeout = 10
+
+    if kwargs is None:
+        kwargs = {}
+
+    expire_at = time.time() + timeout
+
+    while True:
+
+        tx = ZKTransaction(zk, timeout=expire_at - time.time())
+
+        try:
+            with tx:
+                func(tx, *args, **kwargs)
+
+            assert tx.tx_status is not None, 'with-statement guarantees tx_status is not None'
+            return tx.tx_status, tx.txid
+
+        except RetriableError as e:
+            logger.info('{tx} {e}'.format(tx=tx, e=repr(e)))
+            continue
+
+
+def txidstr(txid):
+    return 'tx-{txid:0>10}'.format(txid=txid)


### PR DESCRIPTION
-   Refined exception names.

-   CAS in abstract storage layer support configurable CAS-conflict error.

-   Accessor: add set_or_create(), to update a value without the need of
    knowing if the value exists or not.

-   Accessor.create() accept argument `ephemeral` and `sequence`.

-   tx API: with-statement style or tx-function style.

-   ZKStorage: add watch_acquire_key()