### PR TITLE
Refine zktx

### DIFF
--- a/zktx/README.md
+++ b/zktx/README.md
@@ -26,7 +26,7 @@
   - [zktx.Storage](#zktxstorage)
     - [Storage attributes](#storage-attributes)
     - [Storage methods](#storage-methods)
-      - [Storage.try_lock_key](#storagetry_lock_key)
+      - [Storage.watch_acquire_key](#storagewatch_acquire_key)
       - [Storage.try_release_key](#storagetry_release_key)
     - [Storage helper methods](#storage-helper-methods)
   - [zktx.StorageHelper](#zktxstoragehelper)
@@ -339,28 +339,16 @@ a class that implements `Storage` must provides 3 accessors(`KVAccessor` and `Va
 
 An implementation of `Storage` must implement 2 locking methods:
 
-####  Storage.try_lock_key
+####  Storage.watch_acquire_key
 
 **syntax**:
-`Storage.try_lock_key(txid, key)`
+`Storage.watch_acquire_key(txid, key)`
 
-It is defined as `def try_lock_key(self, txid, key)`.
+It is defined as `def watch_acquire_key(self, txid, key)`.
 
 It tries to lock a `key` for a `txid`: Same `txid` can lock a `key` more than once.
 
-This function should never block and should return at once.
-
-> Because our TX engine need to detect and resolve deadlock, thus locking should
-> be non-blocking.
-
-It should return a 3 element `tuple`:
-
--   A `bool` indicates if locking succeeds.
-
--   A `txid` indicates current lock holder.
-    If locking succeeded, it is the passed in `txid`
-
--   A 3rd value indicates lock stat(not used yet).
+It is a wrapper of `zkutil.ZKLock.watch_acquire`.
 
 
 ####  Storage.try_release_key

--- a/zktx/README.md
+++ b/zktx/README.md
@@ -60,6 +60,9 @@ This library is considered production ready.
 
 Transaction implementation on Zookeeper.
 
+Following chapters describes API of this module.
+To see more about transaction design, See [transaction](transaction.md)
+
 
 #   Synopsis
 

--- a/zktx/README.md
+++ b/zktx/README.md
@@ -408,7 +408,7 @@ It requires 1 accessor method: `self.record.get(key)`.
     specifies the `key` of the record.
 
 **return**:
-a dict in form of `{<txid>: <value>}` and an implementation defined version.
+a tuple `(<txid>, <value>)` and an implementation defined version.
 
 
 ###  StorageHelper.apply_record

--- a/zktx/storage.py
+++ b/zktx/storage.py
@@ -87,6 +87,6 @@ class Storage(StorageHelper):
     journal = KVAccessor()
     txidset = ValueAccessor()
 
-    def try_lock_key(self, txid, key): raise TypeError('unimplemented')
+    def watch_acquire_key(self, txid, key): raise TypeError('unimplemented')
 
     def try_release_key(self, txid, key): raise TypeError('unimplemented')

--- a/zktx/storage.py
+++ b/zktx/storage.py
@@ -31,7 +31,7 @@ class StorageHelper(object):
 
         txids = sorted(c.keys())
         max_txid = txids[-1]
-        return {max_txid: c[max_txid]}, ver
+        return (max_txid, c[max_txid]), ver
 
     def apply_record(self, txid, key, value):
 

--- a/zktx/test/test_storage.py
+++ b/zktx/test/test_storage.py
@@ -100,10 +100,10 @@ class TestTXStorageHelper(unittest.TestCase):
         # get_latest relies on storage.record.get
 
         rst = self.sto.get_latest('foo')
-        self.assertEqual(({17: 17}, 0), rst)
+        self.assertEqual(((17, 17), 0), rst)
 
         rst = self.sto.get_latest('bar')
-        self.assertEqual(({-1: None}, 1), rst)
+        self.assertEqual(((-1,  None), 1), rst)
 
     def test_apply_record(self):
 
@@ -175,8 +175,8 @@ class TestTXStorageHelper(unittest.TestCase):
         dd(latest, ver)
 
         self.assertLessEqual(ver, 1+n_thread*n_repeat)
-        self.assertEqual(n_thread*n_repeat, latest.keys()[0])
-        self.assertEqual(n_thread*n_repeat, latest.values()[0])
+        self.assertEqual(n_thread*n_repeat, latest[0])
+        self.assertEqual(n_thread*n_repeat, latest[1])
 
     def _rand_txids(self):
         for ii in range(100):

--- a/zktx/test/test_tx.py
+++ b/zktx/test/test_tx.py
@@ -112,7 +112,7 @@ class TestTX(base.ZKTestBase):
 
         t = ZKTransaction(zkhost)
         rst, ver = t.zkstorage.get_latest('foo')
-        self.assertEqual(100, rst.values()[0])
+        self.assertEqual(100, rst[1])
 
         rst, ver = self.zk.get('tx/txidset')
         self.assertEqual({COMMITTED: [[1, 2]],
@@ -168,7 +168,7 @@ class TestTX(base.ZKTestBase):
 
         t = ZKTransaction(zkhost)
         rst, ver = t.zkstorage.get_latest('foo')
-        self.assertEqual(100, rst.values()[0])
+        self.assertEqual(100, rst[1])
 
     def test_run_unretriable_error(self):
 
@@ -198,7 +198,7 @@ class TestTX(base.ZKTestBase):
 
         tx = ZKTransaction(zkhost)
         rst, ver = tx.zkstorage.get_latest('foo')
-        self.assertEqual(100, rst.values()[0])
+        self.assertEqual(100, rst[1])
 
     def test_sequential(self):
 
@@ -221,7 +221,7 @@ class TestTX(base.ZKTestBase):
 
         rst, ver = t.zkstorage.get_latest(k)
         dd(rst)
-        self.assertEqual(n_tx, rst.values()[0])
+        self.assertEqual(n_tx, rst[1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -258,7 +258,7 @@ class TestTX(base.ZKTestBase):
 
         rst, ver = t.zkstorage.get_latest('foo')
         dd(rst)
-        self.assertEqual(n_tx, rst.values()[0])
+        self.assertEqual(n_tx, rst[1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -309,7 +309,7 @@ class TestTX(base.ZKTestBase):
         for k in ks:
             rst, ver = t.zkstorage.get_latest(k)
             dd(rst)
-            self.assertEqual(n_tx, rst.values()[0])
+            self.assertEqual(n_tx, rst[1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -340,7 +340,7 @@ class TestTX(base.ZKTestBase):
 
         rst, ver = t.zkstorage.get_latest('foo')
         dd(rst)
-        self.assertEqual(1, rst.values()[0])
+        self.assertEqual(1, rst[1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -370,11 +370,11 @@ class TestTX(base.ZKTestBase):
 
         rst, ver = t.zkstorage.get_latest('foo')
         dd(rst)
-        self.assertEqual(556, rst.values()[0])
+        self.assertEqual(556, rst[1])
 
         rst, ver = t.zkstorage.get_latest('bar')
         dd(rst)
-        self.assertEqual(666, rst.values()[0])
+        self.assertEqual(666, rst[1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -392,7 +392,7 @@ class TestTX(base.ZKTestBase):
 
         rst, ver = t.zkstorage.get_latest('foo')
         dd(rst)
-        self.assertEqual(None, rst.values()[0])
+        self.assertEqual(None, rst[1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)

--- a/zktx/test/test_zkstorage.py
+++ b/zktx/test/test_zkstorage.py
@@ -76,7 +76,7 @@ class TestZKStorage(base.ZKTestBase):
 
         # get_latest
         rst, ver = self.zs.get_latest('foo')
-        self.assertEqual({2: 3}, rst)
+        self.assertEqual((2, 3), rst)
 
     def test_lock(self):
 

--- a/zktx/transaction.md
+++ b/zktx/transaction.md
@@ -97,6 +97,23 @@ Record format:
 ...
 ```
 
+> By default a record value keeps the last 16 txid
+
+
+## Transaction journal and record example
+
+```
+/<cluster>/tx/journal/0000000001      # content: {"meta/server/<server_id>": {...}}
+/<cluster>/tx/journal/0000000002      # content: {"meta/dirve/<drive_id>": {...}}
+/<cluster>/record/meta/server/<server_id>
+/<cluster>/record/meta/drive/<drive_id>
+```
+
+From above, the journal `0000000001` will be applied to
+`/<cluster>/record/meta/server/<server_id>`,
+and `0000000002` will be applied to
+`/<cluster>/record/meta/drive/<drive_id>`,
+
 
 # Concept
 

--- a/zktx/zkstorage.py
+++ b/zktx/zkstorage.py
@@ -48,27 +48,6 @@ class ZKStorage(Storage):
         for holder, ver in keylock.watch_acquire(timeout=timeout):
             yield int(holder), ver
 
-    def try_lock_key(self, txid, key):
-
-        # Use the txid as lock identifier, thus when tx processor recovered,
-        # it could re-acquire this lock with no trouble.
-        #
-        # But we have to guarantee there is only one processor for this tx.
-        # And this is done by let the tx processor to acquire a lock named with txid first.
-
-        logger.info('locking: {txid} {key}'.format(txid=txid, key=key))
-
-        keylock = None
-        try:
-            keylock = self._make_key_lock(txid, key)
-
-            locked, txid, ver = keylock.try_lock()
-            return locked, utfjson.load(txid), ver
-
-        finally:
-            if keylock is not None:
-                keylock.close()
-
     def try_release_key(self, txid, key):
 
         logger.info('releasing: {txid} {key}'.format(txid=txid, key=key))

--- a/zktx/zktx.py
+++ b/zktx/zktx.py
@@ -90,9 +90,7 @@ class ZKTransaction(object):
 
         self.lock_key(key)
 
-        l, version = self.zkstorage.get_latest(key)
-
-        ltxid, lvalue = l.items()[0]
+        (ltxid, lvalue), version = self.zkstorage.get_latest(key)
 
         curr = TXRecord(k=key, v=lvalue, txid=ltxid)
         self.got_keys[key] = curr


### PR DESCRIPTION
- zktx: add transaction workflow explaination
- zktx: ZKStorage.get_latest(): return ((txid, value), version) instead of ({txid: value}, version)
- zktx: add watch_acquire_key(), remove try_lock_key()