### PR TITLE
zktx: change record format to list of list

### DIFF
--- a/zktx/README.md
+++ b/zktx/README.md
@@ -30,7 +30,6 @@
       - [Storage.try_release_key](#storagetry_release_key)
     - [Storage helper methods](#storage-helper-methods)
   - [zktx.StorageHelper](#zktxstoragehelper)
-    - [StorageHelper.get_latest](#storagehelperget_latest)
     - [StorageHelper.apply_record](#storagehelperapply_record)
     - [StorageHelper.add_to_txidset](#storagehelperadd_to_txidset)
   - [zktx.ZKStorage](#zktxzkstorage)
@@ -392,24 +391,6 @@ See `StorageHelper`.
 It provides 3 methods those a TX engine relies on.
 Since underlying accessors has already been provided, these 3 methods are
 implementation unrelated.
-
-
-###  StorageHelper.get_latest
-
-**syntax**:
-`StorageHelper.get_latest(key)`
-
-It returns the latest update(the update with the greatest txid) of a record identified by `key`.
-
-It requires 1 accessor method: `self.record.get(key)`.
-
-**arguments**:
-
--   `key`:
-    specifies the `key` of the record.
-
-**return**:
-a 2 element list `[<txid>, <value>]` and an implementation defined version.
 
 
 ###  StorageHelper.apply_record

--- a/zktx/README.md
+++ b/zktx/README.md
@@ -298,14 +298,12 @@ a class that implements `Storage` must provides 3 accessors(`KVAccessor` and `Va
 -   `record`:
     is a `KVAccessor` to get or set a user-data record.
 
-    A record value is a `dict` map of `txid` to value:
+    A record value is a `list` of `[txid, value]`:
 
     ```python
-    {
-        <txid>: <value>
-        <txid>: <value>
-        ...
-    }
+    [[1, "foo"],
+     [2, "bar"],
+    ]
     ```
 
 -   `journal`:
@@ -411,7 +409,7 @@ It requires 1 accessor method: `self.record.get(key)`.
     specifies the `key` of the record.
 
 **return**:
-a tuple `(<txid>, <value>)` and an implementation defined version.
+a 2 element list `[<txid>, <value>]` and an implementation defined version.
 
 
 ###  StorageHelper.apply_record

--- a/zktx/storage.py
+++ b/zktx/storage.py
@@ -19,22 +19,14 @@ class StorageHelper(object):
     max_value_history = 16
     conflicterror = None
 
-    def get_latest(self, key):
-        """
-        return: (<txid>, <value>), zk_version
-        """
-
-        c, ver = self.record.get(key)
-        return c[-1], ver
-
     def apply_record(self, txid, key, value):
 
         # the data in underlying storage is multi-version record:
-        # {
-        #     <txid>: <value>
-        #     <txid>: <value>
+        # [
+        #     [<txid>, <value>]
+        #     [<txid>, <value>]
         #     ...
-        # }
+        # ]
 
         for curr in txutil.cas_loop(self.record.get,
                                     self.record.set_or_create,

--- a/zktx/storage.py
+++ b/zktx/storage.py
@@ -21,17 +21,11 @@ class StorageHelper(object):
 
     def get_latest(self, key):
         """
-        return: (
-                    {<txid> : <value>},
-                    zk_version,
-                )
+        return: (<txid>, <value>), zk_version
         """
 
         c, ver = self.record.get(key)
-
-        txids = sorted(c.keys())
-        max_txid = txids[-1]
-        return (max_txid, c[max_txid]), ver
+        return c[-1], ver
 
     def apply_record(self, txid, key, value):
 
@@ -47,17 +41,14 @@ class StorageHelper(object):
                                     args=(key, ),
                                     conflicterror=self.conflicterror):
 
-            max_txid = -1
-            txids = sorted(curr.v.keys())
-            if len(txids) > 0:
-                max_txid = max(txids)
+            max_txid = curr.v[-1][0]
 
             if max_txid >= txid:
                 return False
 
-            curr.v[txid] = value
-            if len(curr.v) > self.max_value_history:
-                del curr.v[txids[0]]
+            curr.v.append((txid, value))
+            while len(curr.v) > self.max_value_history:
+                curr.v.pop(0)
 
         return True
 

--- a/zktx/test/test_storage.py
+++ b/zktx/test/test_storage.py
@@ -83,8 +83,8 @@ class PseudoStorage(zktx.StorageHelper):
 
     def __init__(self):
         self.record = PseudoKVAccessor({
-            'foo': ({k: k for k in (1, 17)}, 0),
-            'bar': ({-1: None}, 1),
+            'foo': ([[1, 1], [17, 17]], 0),
+            'bar': ([[-1, None]], 1),
         })
 
         self.txidset = TxidsetAccessor()
@@ -100,10 +100,10 @@ class TestTXStorageHelper(unittest.TestCase):
         # get_latest relies on storage.record.get
 
         rst = self.sto.get_latest('foo')
-        self.assertEqual(((17, 17), 0), rst)
+        self.assertEqual(([17, 17], 0), rst)
 
         rst = self.sto.get_latest('bar')
-        self.assertEqual(((-1,  None), 1), rst)
+        self.assertEqual(([-1,  None], 1), rst)
 
     def test_apply_record(self):
 
@@ -124,7 +124,8 @@ class TestTXStorageHelper(unittest.TestCase):
             self.sto.apply_record(txid, key, value)
 
             rec, ver = self.sto.record.get(key)
-            self.assertEqual(expected, (rec.get(txid), ver))
+            val_of_txid = dict(rec).get(txid)
+            self.assertEqual(expected, (val_of_txid, ver))
 
     def test_apply_record_max_history(self):
 
@@ -169,7 +170,7 @@ class TestTXStorageHelper(unittest.TestCase):
         dd(ver)
 
         self.assertEqual(set(success_tx.keys()),
-                         set(rec.keys()))
+                         set([x[0] for x in rec]))
 
         latest, ver = self.sto.get_latest('bar')
         dd(latest, ver)

--- a/zktx/test/test_storage.py
+++ b/zktx/test/test_storage.py
@@ -97,13 +97,11 @@ class TestTXStorageHelper(unittest.TestCase):
 
     def test_get_latest(self):
 
-        # get_latest relies on storage.record.get
+        rst = self.sto.record.get('foo')
+        self.assertEqual(([[1, 1], [17, 17]], 0), rst)
 
-        rst = self.sto.get_latest('foo')
-        self.assertEqual(([17, 17], 0), rst)
-
-        rst = self.sto.get_latest('bar')
-        self.assertEqual(([-1,  None], 1), rst)
+        rst = self.sto.record.get('bar')
+        self.assertEqual(([[-1,  None]], 1), rst)
 
     def test_apply_record(self):
 
@@ -172,12 +170,12 @@ class TestTXStorageHelper(unittest.TestCase):
         self.assertEqual(set(success_tx.keys()),
                          set([x[0] for x in rec]))
 
-        latest, ver = self.sto.get_latest('bar')
-        dd(latest, ver)
+        rec, ver = self.sto.record.get('bar')
+        dd(rec, ver)
 
         self.assertLessEqual(ver, 1+n_thread*n_repeat)
-        self.assertEqual(n_thread*n_repeat, latest[0])
-        self.assertEqual(n_thread*n_repeat, latest[1])
+        self.assertEqual(n_thread*n_repeat, rec[-1][0])
+        self.assertEqual(n_thread*n_repeat, rec[-1][1])
 
     def _rand_txids(self):
         for ii in range(100):

--- a/zktx/test/test_tx.py
+++ b/zktx/test/test_tx.py
@@ -53,7 +53,7 @@ class TestTX(base.ZKTestBase):
         tx.commit()
 
         rst, ver = self.zk.get('record/foo')
-        self.assertEqual({'-1': None, '1': 1}, utfjson.load(rst))
+        self.assertEqual([[-1, None], [1, 1]], utfjson.load(rst))
 
         rst, ver = self.zk.get('tx/txidset')
         self.assertEqual({COMMITTED: [[1, 2]],
@@ -73,7 +73,7 @@ class TestTX(base.ZKTestBase):
             t1.commit()
 
         rst, ver = self.zk.get('record/foo')
-        self.assertEqual({'-1': None, '1': 1}, utfjson.load(rst))
+        self.assertEqual([[-1, None], [1, 1]], utfjson.load(rst))
 
         rst, ver = self.zk.get('tx/txidset')
         self.assertEqual({COMMITTED: [[1, 2]],
@@ -97,7 +97,7 @@ class TestTX(base.ZKTestBase):
             t1.commit()
 
         rst, ver = self.zk.get('record/foo')
-        self.assertEqual({'-1': None, '1': 2}, utfjson.load(rst))
+        self.assertEqual([[-1, None], [1, 2]], utfjson.load(rst))
 
     def test_run(self):
 

--- a/zktx/test/test_tx.py
+++ b/zktx/test/test_tx.py
@@ -99,7 +99,7 @@ class TestTX(base.ZKTestBase):
         rst, ver = self.zk.get('record/foo')
         self.assertEqual([[-1, None], [1, 2]], utfjson.load(rst))
 
-    def test_run(self):
+    def test_run_tx(self):
 
         def _tx(tx):
             foo = tx.lock_get('foo')
@@ -111,8 +111,8 @@ class TestTX(base.ZKTestBase):
         self.assertEqual((COMMITTED, 1), (status, txid))
 
         t = ZKTransaction(zkhost)
-        rst, ver = t.zkstorage.get_latest('foo')
-        self.assertEqual(100, rst[1])
+        rst, ver = t.zkstorage.record.get('foo')
+        self.assertEqual(100, rst[-1][1])
 
         rst, ver = self.zk.get('tx/txidset')
         self.assertEqual({COMMITTED: [[1, 2]],
@@ -120,7 +120,7 @@ class TestTX(base.ZKTestBase):
                           PURGED: [],
                           }, utfjson.load(rst))
 
-    def test_run_timeout(self):
+    def test_run_tx_timeout(self):
 
         def _tx(tx):
             tx.lock_get('foo')
@@ -133,7 +133,7 @@ class TestTX(base.ZKTestBase):
         except TXTimeout as e:
             dd(repr(e))
 
-    def test_run_conn_loss(self):
+    def test_run_tx_conn_loss(self):
 
         def _tx(tx):
             tx.lock_get('foo')
@@ -146,7 +146,7 @@ class TestTX(base.ZKTestBase):
         except ConnectionLoss as e:
             dd(repr(e))
 
-    def test_run_retriable_error(self):
+    def test_run_tx_retriable_error(self):
 
         errs = [HigherTXApplied, Deadlock, None]
 
@@ -167,10 +167,10 @@ class TestTX(base.ZKTestBase):
         self.assertEqual((COMMITTED, 3), (status, txid))
 
         t = ZKTransaction(zkhost)
-        rst, ver = t.zkstorage.get_latest('foo')
-        self.assertEqual(100, rst[1])
+        rst, ver = t.zkstorage.record.get('foo')
+        self.assertEqual(100, rst[-1][1])
 
-    def test_run_unretriable_error(self):
+    def test_run_tx_unretriable_error(self):
 
         sess = dict(n=0)
         errs = [UserAborted, TXTimeout, ConnectionLoss, None]
@@ -197,8 +197,8 @@ class TestTX(base.ZKTestBase):
         self.assertEqual(len(errs), sess['n'])
 
         tx = ZKTransaction(zkhost)
-        rst, ver = tx.zkstorage.get_latest('foo')
-        self.assertEqual(100, rst[1])
+        rst, ver = tx.zkstorage.record.get('foo')
+        self.assertEqual(100, rst[-1][1])
 
     def test_sequential(self):
 
@@ -219,9 +219,9 @@ class TestTX(base.ZKTestBase):
 
         t = ZKTransaction(zkhost)
 
-        rst, ver = t.zkstorage.get_latest(k)
+        rst, ver = t.zkstorage.record.get(k)
         dd(rst)
-        self.assertEqual(n_tx, rst[1])
+        self.assertEqual(n_tx, rst[-1][1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -256,9 +256,9 @@ class TestTX(base.ZKTestBase):
 
         t = ZKTransaction(zkhost)
 
-        rst, ver = t.zkstorage.get_latest('foo')
+        rst, ver = t.zkstorage.record.get('foo')
         dd(rst)
-        self.assertEqual(n_tx, rst[1])
+        self.assertEqual(n_tx, rst[-1][1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -307,9 +307,9 @@ class TestTX(base.ZKTestBase):
         t = ZKTransaction(zkhost)
 
         for k in ks:
-            rst, ver = t.zkstorage.get_latest(k)
+            rst, ver = t.zkstorage.record.get(k)
             dd(rst)
-            self.assertEqual(n_tx, rst[1])
+            self.assertEqual(n_tx, rst[-1][1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -338,9 +338,9 @@ class TestTX(base.ZKTestBase):
 
         t = ZKTransaction(zkhost)
 
-        rst, ver = t.zkstorage.get_latest('foo')
+        rst, ver = t.zkstorage.record.get('foo')
         dd(rst)
-        self.assertEqual(1, rst[1])
+        self.assertEqual(1, rst[-1][1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -368,13 +368,13 @@ class TestTX(base.ZKTestBase):
 
         t = ZKTransaction(zkhost)
 
-        rst, ver = t.zkstorage.get_latest('foo')
+        rst, ver = t.zkstorage.record.get('foo')
         dd(rst)
-        self.assertEqual(556, rst[1])
+        self.assertEqual(556, rst[-1][1])
 
-        rst, ver = t.zkstorage.get_latest('bar')
+        rst, ver = t.zkstorage.record.get('bar')
         dd(rst)
-        self.assertEqual(666, rst[1])
+        self.assertEqual(666, rst[-1][1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)
@@ -390,9 +390,9 @@ class TestTX(base.ZKTestBase):
 
         t = ZKTransaction(zkhost)
 
-        rst, ver = t.zkstorage.get_latest('foo')
+        rst, ver = t.zkstorage.record.get('foo')
         dd(rst)
-        self.assertEqual(None, rst[1])
+        self.assertEqual(None, rst[-1][1])
 
         rst, ver = t.zkstorage.txidset.get()
         dd(rst)

--- a/zktx/test/test_zkstorage.py
+++ b/zktx/test/test_zkstorage.py
@@ -57,26 +57,26 @@ class TestZKStorage(base.ZKTestBase):
 
         # nonode_callback
         rst, ver = self.zs.record.get('foo')
-        self.assertEqual({-1: None}, rst)
+        self.assertEqual([(-1, None)], rst)
 
-        self.zs.record.create('foo', {1: 1})
+        self.zs.record.create('foo', [(1, 1)])
 
         # record_load
         rst, ver = self.zs.record.get('foo')
-        self.assertEqual({1: 1}, rst)
+        self.assertEqual([[1, 1]], rst)
 
-        self.zs.record.set('foo', {1: 2})
+        self.zs.record.set('foo', [(1, 2)])
         rst, ver = self.zs.record.get('foo')
-        self.assertEqual({1: 2}, rst)
+        self.assertEqual([[1, 2]], rst)
 
         # apply_record
         self.zs.apply_record(2, 'foo', 3)
         rst, ver = self.zs.record.get('foo')
-        self.assertEqual({1: 2, 2: 3}, rst)
+        self.assertEqual([[1, 2], [2, 3]], rst)
 
         # get_latest
         rst, ver = self.zs.get_latest('foo')
-        self.assertEqual((2, 3), rst)
+        self.assertEqual([2, 3], rst)
 
     def test_lock(self):
 

--- a/zktx/test/test_zkstorage.py
+++ b/zktx/test/test_zkstorage.py
@@ -74,10 +74,6 @@ class TestZKStorage(base.ZKTestBase):
         rst, ver = self.zs.record.get('foo')
         self.assertEqual([[1, 2], [2, 3]], rst)
 
-        # get_latest
-        rst, ver = self.zs.get_latest('foo')
-        self.assertEqual([2, 3], rst)
-
     def test_lock(self):
 
         for holder, ver in self.zs.watch_acquire_key(2, 'foo', 10):

--- a/zktx/transaction.md
+++ b/zktx/transaction.md
@@ -6,6 +6,7 @@
   - [Proceeding a transaction](#proceeding-a-transaction)
   - [Journal format](#journal-format)
   - [Record](#record)
+  - [Transaction journal and record example](#transaction-journal-and-record-example)
 - [Concept](#concept)
 - [A typical transaction running phases](#a-typical-transaction-running-phases)
   - [For tx killed in phase 0, 1, 2, 3](#for-tx-killed-in-phase-0-1-2-3)
@@ -85,15 +86,16 @@ A tx would update one or more records.
 A record is a zk node in user-defined record base dir, such as
 `<cluster>/record/meta/server/<server_id>`.
 
-Value of a record is a json(or yaml), it contains one or more mapping of txid to value.
+Value of a record is a json(or yaml) list, which contains one or more `(txid, value)`
+pairs(empty list is illegal!).
 
 `txid` is the txid in which a value is applied, value is any json data.
 
 Record format:
 
 ```yaml
-<txid-1>: {...}
-<txid-2>: {...}
+- [1, {...}]
+- [2, {...}]
 ...
 ```
 

--- a/zktx/zkstorage.py
+++ b/zktx/zkstorage.py
@@ -36,7 +36,6 @@ class ZKStorage(Storage):
 
         self.record = ZKKeyValue(self.zkclient,
                                  self.zkclient._zkconf.record,
-                                 load=record_load,
                                  nonode_callback=record_nonode_cb)
 
     def watch_acquire_key(self, txid, key, timeout):
@@ -81,22 +80,9 @@ def txidset_load(value):
     return rst
 
 
-def record_load(value):
-
-    # json does not support int as key.
-    # It converts int to str.
-    # We need to convert it back to int
-
-    rst = {int(k): v
-           for k, v in value.items()}
-    if len(rst) == 0:
-        rst[-1] = None
-    return rst
-
-
 def record_nonode_cb():
     """
     If NoNodeError received, make a default value for a record
     """
 
-    return {-1: None}, -1
+    return [(-1, None)], -1

--- a/zktx/zktx.py
+++ b/zktx/zktx.py
@@ -90,7 +90,8 @@ class ZKTransaction(object):
 
         self.lock_key(key)
 
-        (ltxid, lvalue), version = self.zkstorage.get_latest(key)
+        val, version = self.zkstorage.record.get(key)
+        ltxid, lvalue = val[-1]
 
         curr = TXRecord(k=key, v=lvalue, txid=ltxid)
         self.got_keys[key] = curr


### PR DESCRIPTION
from: ` { txid-1: value, txid-2: value } `
to: ` [[txid-1, value], [txid-2, value]] `

remove get_latest, use record.get('foo')[0][-1] to retrieve latest updated value