### PR TITLE
fsutil.cat: buffer last read line if it does not end with '\n'.

### DIFF
--- a/fsutil/__init__.py
+++ b/fsutil/__init__.py
@@ -20,12 +20,13 @@ from .fsutil import (
 )
 
 from .cat import (
+    SEEK_END,
+    SEEK_START,
+
     CatError,
     LockTimeout,
     NoData,
     NoSuchFile,
-    SEEK_END,
-    SEEK_START,
     Cat
 )
 
@@ -49,6 +50,9 @@ __all__ = [
     "remove",
     "write_file",
 
+
+    "SEEK_END",
+    "SEEK_START",
 
     "CatError",
     "LockTimeout",


### PR DESCRIPTION
The bufferred last chunk will be yield after timeout,
no matter if it ends with '\n'.

fix: #262 