### PR TITLE
zktx.lock_get() add arg blocking, by default is True

### DIFF
--- a/zktx/README.md
+++ b/zktx/README.md
@@ -639,7 +639,7 @@ It is a transaction engine.
 ###  ZKTransaction.lock_get
 
 **syntax**:
-`ZKTransaction.lock_get(key)`
+`ZKTransaction.lock_get(key, blocking=True)`
 
 Lock a record identified by `key` and retrieve the record and return.
 
@@ -654,6 +654,11 @@ But it always returns a copy of the first returned `TXRecord`.
 
 -   `key`:
     is the record key in string.
+
+-   `blocking`:
+    if `blocking` is `False`, it does not block if the key lock is held by other
+    tx.
+    Instead it returns `None` at once.
 
 **return**:
 a `TXRecord` instance.

--- a/zktx/test/test_tx.py
+++ b/zktx/test/test_tx.py
@@ -103,6 +103,19 @@ class TestTX(TXBase):
         rst, ver = self.zk.get('record/foo')
         self.assertEqual([[-1, None], [1, 2]], utfjson.load(rst))
 
+    def test_noblocking_lock_get(self):
+
+        with ZKTransaction(zkhost) as t1:
+
+            t1.lock_get('foo')
+            f2 = t1.lock_get('foo', blocking=False)
+            self.assertIsNotNone(f2)
+
+            with ZKTransaction(zkhost) as t2:
+
+                f4 = t2.lock_get('foo', blocking=False)
+                self.assertIsNone(f4)
+
     def test_run_tx(self):
 
         def _tx(tx):


### PR DESCRIPTION
fix #284 