### PR TITLE
cluster: refine

### DIFF
--- a/cluster/block.py
+++ b/cluster/block.py
@@ -3,6 +3,8 @@
 
 from collections import namedtuple
 
+from .server import DriveID
+
 BlockIDLen = 48
 
 
@@ -25,10 +27,21 @@ class BlockID(namedtuple('_BlockID', 'type block_group_id block_index drive_id p
 
         pg_seq = int(block_id[-10:])
 
-        return BlockID(block_id[:2], block_id[2:18], block_id[18:22], block_id[22:38], pg_seq)
+        return BlockID(block_id[:2], block_id[2:18], block_id[18:22], DriveID.parse(block_id[22:38]), pg_seq)
+
+    def __init__(self, type, block_group_id, block_index, drive_id, pg_seq):
+        if isinstance(drive_id, DriveID):
+            pass
+        else:
+            drive_id = DriveID.parse(drive_id)
+
+        super(BlockID, self).__init__(type, block_group_id, block_index, drive_id, pg_seq)
 
     def __str__(self):
 
         pg_seq = '%010d' % self.pg_seq
 
-        return self.type + self.block_group_id + self.block_index + self.drive_id + pg_seq
+        return self.type + self.block_group_id + self.block_index + self.drive_id.tostr() + pg_seq
+
+    def tostr(self):
+        return str(self)

--- a/cluster/block_group.py
+++ b/cluster/block_group.py
@@ -34,3 +34,6 @@ class BlockGroupID(namedtuple('_BlockGroupID', 'block_size seq')):
         seq = '%010d' % self.seq
 
         return 'g' + blk_size + seq
+
+    def tostr(self):
+        return str(self)

--- a/cluster/test/test_block.py
+++ b/cluster/test/test_block.py
@@ -12,7 +12,7 @@ class TestClusterBlock(unittest.TestCase):
 
         block_id = 'd1g0006300000001230101c62d8736c72800020000000001'
 
-        bid = cluster.BlockID('d1', 'g000630000000123', '0101', 'c62d8736c7280002', 1)
+        bid = cluster.BlockID('d1', 'g000630000000123', '0101', cluster.DriveID.parse('c62d8736c7280002'), 1)
         self.assertEqual(block_id, str(bid))
 
         bid = cluster.BlockID.parse(block_id)
@@ -20,15 +20,29 @@ class TestClusterBlock(unittest.TestCase):
         self.assertEqual('d1', bid.type)
         self.assertEqual('g000630000000123', bid.block_group_id)
         self.assertEqual('0101', bid.block_index)
-        self.assertEqual('c62d8736c7280002', bid.drive_id)
+        self.assertEqual('c62d8736c7280002', bid.drive_id.tostr())
         self.assertEqual(1, bid.pg_seq)
 
         self.assertEqual(block_id, str(bid))
         self.assertEqual(block_id, '{0}'.format(bid))
         self.assertEqual(
-            "_BlockID(type='d1', block_group_id='g000630000000123', block_index='0101', drive_id='c62d8736c7280002', pg_seq=1)", repr(bid))
+            "_BlockID(type='d1', block_group_id='g000630000000123', block_index='0101', drive_id=_DriveID(server_id='c62d8736c728', mountpoint_index=2), pg_seq=1)",
+            repr(bid))
 
         # test invalid input
         block_id_invalid = 'd1g0006300000001230101c62d8736c728000200000'
         self.assertRaises(cluster.BlockIDError,
                           cluster.BlockID.parse, block_id_invalid)
+
+    def test_tostr(self):
+
+        block_id = 'd1g0006300000001230101c62d8736c72800020000000001'
+        bid = cluster.BlockID.parse(block_id)
+
+        self.assertEqual(block_id, bid.tostr())
+        self.assertEqual(block_id, str(bid))
+
+        self.assertIsInstance(bid.drive_id, cluster.DriveID)
+        self.assertEqual('c62d8736c7280002', str(bid.drive_id))
+        self.assertEqual('c62d8736c7280002', bid.drive_id.tostr())
+        self.assertEqual('c62d8736c728', bid.drive_id.server_id)

--- a/cluster/test/test_block_group.py
+++ b/cluster/test/test_block_group.py
@@ -29,3 +29,9 @@ class TestClusterBlockGroup(unittest.TestCase):
         block_group_id_invalid = 'g00064000000012345'
         self.assertRaises(cluster.BlockGroupIDError,
                           cluster.BlockGroupID.parse, block_group_id_invalid)
+
+    def test_tostr(self):
+        block_group_id = 'g000640000000123'
+        bgid = cluster.BlockGroupID.parse(block_group_id)
+        self.assertEqual(block_group_id, str(bgid))
+        self.assertEqual(block_group_id, bgid.tostr())


### PR DESCRIPTION
-   BlockID, DriveID and BlockGroupID adds `tostr()` method.
-   Parse ids recursively:
    -   BlockID.drive_id is a DriveID instance.
    -   BlockID.block_group_id is a BlockGroupID instance.