### PR TITLE
ectypes: `str` based xxID implementation.

### DIFF
--- a/ectypes/README.md
+++ b/ectypes/README.md
@@ -15,30 +15,23 @@
 - [Classes](#classes)
   - [ectypes.ReplicationConfig](#ectypesreplicationconfig)
   - [ectypes.ServerID](#ectypesserverid)
-    - [ectypes.ServerID.validate](#ectypesserveridvalidate)
   - [ectypes.DriveID](#ectypesdriveid)
-    - [ectypes.DriveID.validate](#ectypesdriveidvalidate)
     - [ectypes.DriveID.parse](#ectypesdriveidparse)
-    - [ectypes.DriveID.tostr](#ectypesdriveidtostr)
 - [Methods](#methods)
   - [ectypes.make_serverrec](#ectypesmake_serverrec)
   - [ectypes.get_serverrec_str](#ectypesget_serverrec_str)
   - [ectypes.validate_idc](#ectypesvalidate_idc)
   - [ectypes.idc_distance](#ectypesidc_distance)
-  - [ectypes.json_dump](#ectypesjson_dump)
-  - [ectypes.json_load](#ectypesjson_load)
 - [Classes](#classes-1)
   - [ectypes.BlockID](#ectypesblockid)
     - [block id](#block-id)
     - [ectypes.BlockID.parse](#ectypesblockidparse)
     - [ectypes.BlockID.`__str__`](#ectypesblockid__str__)
-  - [ectypes.BlockID.tostr](#ectypesblockidtostr)
   - [ectypes.BlockDesc](#ectypesblockdesc)
   - [ectypes.BlockGroupID](#ectypesblockgroupid)
     - [block group id](#block-group-id)
     - [ectypes.BlockGroupID.parse](#ectypesblockgroupidparse)
     - [ectypes.BlockGroupID.`__str__`](#ectypesblockgroupid__str__)
-  - [ectypes.BlockGroupID.tostr](#ectypesblockgroupidtostr)
   - [ectypes.BlockGroup](#ectypesblockgroup)
     - [block index](#block-index)
     - [ectypes.BlockGroup.get_block](#ectypesblockgroupget_block)
@@ -75,9 +68,6 @@ from pykit import ectypes
 
 server_id = ectypes.ServerID.local_server_id()
 # 12 chars from primary MAC addr: "c62d8736c728"
-
-is_valid = ectypes.ServerID.validate(server_id)
-# return True or False
 
 serverrec = ectypes.make_serverrec('.l1', 'center', {'role1': 1}, "/s2")
 # out:
@@ -197,21 +187,6 @@ print ectypes.ServerID.local_server_id()
 # out: 00163e0630f7
 ```
 
-### ectypes.ServerID.validate
-
-**syntax**:
-`ectypes.ServerID.validate(server_id)`
-
-It is a classmethod for checking a server id.
-
-**arguments**:
-
--   `server_id`:
-    A `str` which will be checked.
-
-**return**:
-`True` or `False`, means the `server_id` is valid or not.
-
 ##  ectypes.DriveID
 
 **syntax**:
@@ -234,21 +209,6 @@ print str(ectypes.DriveID('aabbccddeeff', 10))
 # out: aabbccddeeff0010
 ```
 
-### ectypes.DriveID.validate
-
-**syntax**:
-`ectypes.DriveID.validate(drive_id)`
-
-It is a classmethod for checking a drive id.
-
-**arguments**:
-
--   `drive_id`:
-    A `str` which will be checked.
-
-**return**:
-`True` or `False`, means the `drive_id` is valid or not.
-
 ### ectypes.DriveID.parse
 
 **syntax**:
@@ -267,20 +227,6 @@ Raise a `DriveIDError` if the `drive_id` is invalid.
 **return**:
 A `namedtuple` contains `server_id` and `mount_point_index`.
 
-###  ectypes.DriveID.tostr
-
-**syntax**:
-`ectypes.DriveID.tostr()`
-
-Convert this DriveID instance into a string:
-
-```python
-print ectypes.DriveID('aabbccddeeff', 10).tostr()
-# out: aabbccddeeff0010
-```
-
-**return**:
-a string
 
 
 #   Methods
@@ -397,23 +343,6 @@ Estimate distance between two idc.
 
 **return**:
 The distance of them.
-
-
-##  ectypes.json_dump
-
-**syntax**:
-`ectypes.json_dump(val, encoding='utf-8')`
-
-Implementation of `pykit.utfjson.dump`.
-Preferentially convert pykit.ectypes.IDBase to string.
-
-
-##  ectypes.json_load
-
-**syntax**:
-`ectypes.json_load(json_string, encoding=None)`
-
-Implementation of `pykit.utfjson.load`.
 
 
 #   Classes
@@ -543,14 +472,6 @@ print bid.block_id_seq    # 1
 print bid                 # d0g0006300000001230101c62d8736c72800020000000001
 ```
 
-##  ectypes.BlockID.tostr
-
-**syntax**:
-`ectypes.BlockID.tostr()`
-
-Same as `str(ectypes.BlockID(...))`
-
-
 ##  ectypes.BlockDesc
 
 **syntax**:
@@ -635,12 +556,6 @@ print bgid.seq         # 123
 print bgid             # g000640000000123
 ```
 
-##  ectypes.BlockGroupID.tostr
-
-**syntax**:
-`ectypes.BlockGroupID.tostr()`
-
-Same as `str(ectypes.BlockGroupID(...))`
 
 ## ectypes.BlockGroup
 

--- a/ectypes/__init__.py
+++ b/ectypes/__init__.py
@@ -1,11 +1,5 @@
-from .idbase import (
-    json_dump,
-    json_load,
-)
-
 from .block_id import (
     BlockID,
-    BlockIDError,
 )
 
 from .block_desc import(
@@ -13,9 +7,6 @@ from .block_desc import(
 )
 
 from .block_index import (
-
-    BlockIndexError,
-
     BlockIndex,
 )
 
@@ -29,8 +20,6 @@ from .block_group import (
 )
 
 from .block_group_id import (
-    BlockGroupIDError,
-
     BlockGroupID,
 )
 
@@ -59,9 +48,6 @@ from .region import (
 )
 
 __all__ = [
-    "json_dump",
-    "json_load",
-
     "BlockID",
     "BlockIDError",
 

--- a/ectypes/block_group_id.py
+++ b/ectypes/block_group_id.py
@@ -1,37 +1,19 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from collections import namedtuple
 
 from .idbase import IDBase
 
 BlockGroupIDLen = 16
 
 
-class BlockGroupIDError(Exception):
-    pass
+class BlockGroupID(IDBase):
 
+    _attrs = (
+        ('block_size', 1, 6, int),
+        ('seq', 6, 16, int),
+    )
 
-class BlockGroupID(namedtuple('_BlockGroupID', 'block_size seq'), IDBase):
+    _str_len = 16
 
     _tostr_fmt = 'g{block_size:0>5}{seq:0>10}'
-
-    @classmethod
-    def parse(cls, block_group_id):
-
-        gid = str(block_group_id)
-
-        if len(gid) != BlockGroupIDLen:
-            raise BlockGroupIDError('Block group id length should be {0}, but is {1}: {2}'.format(
-                BlockGroupIDLen, len(gid), gid))
-
-        size = int(gid[1:6])
-        seq = int(gid[6:])
-
-        return BlockGroupID(size, seq)
-
-    def __new__(clz, block_size, seq):
-        block_size = int(block_size)
-        seq = int(seq)
-
-        return super(BlockGroupID, clz).__new__(clz, block_size, seq)

--- a/ectypes/block_id.py
+++ b/ectypes/block_id.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python2
 # coding: utf-8
 
-from collections import namedtuple
 
 from .block_group_id import BlockGroupID
 from .block_index import BlockIndex
@@ -11,44 +10,15 @@ from .server import DriveID
 BlockIDLen = 48
 
 
-class BlockBaseError(Exception):
-    pass
+class BlockID(IDBase):
+    _attrs = (
+        ('type',           0,  2,  str),
+        ('block_group_id', 2,  18, BlockGroupID),
+        ('block_index',    18, 22, BlockIndex),
+        ('drive_id',       22, 38, DriveID),
+        ('block_id_seq',   38, 48, int),
+    )
 
-
-class BlockIDError(BlockBaseError):
-    pass
-
-
-class BlockID(namedtuple('_BlockID', 'type block_group_id block_index drive_id block_id_seq'), IDBase):
+    _str_len = 48
 
     _tostr_fmt = '{type}{block_group_id}{block_index}{drive_id}{block_id_seq:0>10}'
-
-    @classmethod
-    def parse(cls, block_id):
-
-        bid = str(block_id)
-
-        if len(bid) != BlockIDLen:
-            raise BlockIDError('Block id length should be {0}, but is {1}: {2}'.format(
-                BlockIDLen, len(bid), bid))
-
-        return BlockID(bid[:2],
-                       bid[2:18],
-                       bid[18:22],
-                       bid[22:38],
-                       bid[-10:])
-
-    def __new__(clz, type, block_group_id, block_index, drive_id, block_id_seq):
-
-        if not isinstance(block_group_id, BlockGroupID):
-            block_group_id = BlockGroupID.parse(block_group_id)
-
-        if not isinstance(block_index, BlockIndex):
-            block_index = BlockIndex.parse(block_index)
-
-        if not isinstance(drive_id, DriveID):
-            drive_id = DriveID.parse(drive_id)
-
-        block_id_seq = int(block_id_seq)
-
-        return super(BlockID, clz).__new__(clz, type, block_group_id, block_index, drive_id, block_id_seq)

--- a/ectypes/block_index.py
+++ b/ectypes/block_index.py
@@ -1,41 +1,30 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from collections import namedtuple
 
 from .idbase import IDBase
 
 
-class BlockIndexError(ValueError):
-    pass
+def _idx(n):
+
+    try:
+        n = int(n)
+    except ValueError:
+        raise ValueError('index i and j must be int or int-str but: {n}'.format(n=n))
+
+    if not (0 <= n <= 99):
+        raise ValueError('index i and j must be 0~99, but: {n}'.format(n=n))
+
+    return n
 
 
-class BlockIndex(namedtuple('_BlockIndex', 'i j'), IDBase):
+class BlockIndex(IDBase):
+
+    _attrs = (
+        ('i', 0, 2, _idx),
+        ('j', 2, 4, _idx),
+    )
+
+    _str_len = 4
 
     _tostr_fmt = '{i:0>2}{j:0>2}'
-
-    @classmethod
-    def parse(clz, block_index):
-        bi = str(block_index)
-
-        if len(bi) != 4:
-            raise BlockIndexError('block_index len must be 4, but: {bi}'.format(
-                bi=bi))
-
-        ii, jj = bi[:2], bi[2:]
-
-        return BlockIndex(ii, jj)
-
-    def __new__(clz, i, j):
-        try:
-            i = int(i)
-            j = int(j)
-        except ValueError:
-            raise BlockIndexError('index i and j must be int or int-str but: {i} {j}'.format(i=i, j=j))
-
-        if not (0 <= i <= 99):
-            raise BlockIndexError('idc index must be 0~99, but: {i}'.format(i=i))
-        if not (0 <= j <= 99):
-            raise BlockIndexError('cross idc index must be 0~99, but: {j}'.format(j=j))
-
-        return super(BlockIndex, clz).__new__(clz, i, j)

--- a/ectypes/test/test_block_desc.py
+++ b/ectypes/test/test_block_desc.py
@@ -5,6 +5,7 @@ import unittest
 
 from pykit import ectypes
 from pykit import rangeset
+from pykit import utfjson
 
 
 class TestClusterBlockDesc(unittest.TestCase):
@@ -46,3 +47,22 @@ class TestClusterBlockDesc(unittest.TestCase):
         self.assertRaises(ValueError, ectypes.BlockDesc, is_del='a')
         self.assertRaises(ValueError, ectypes.BlockDesc, size='a')
         self.assertRaises(KeyError, ectypes.BlockDesc, a=3)
+
+    def test_json(self):
+        blk = ectypes.BlockDesc({
+            'block_id': ectypes.BlockID('d0',
+                                        'g000640000000123',
+                                        '0000',
+                                        ectypes.DriveID.parse('c62d8736c7280002'),
+                                        1),
+            'size': 1000,
+            'range': ['0a', '0b'],
+            'is_del': 0
+        })
+
+        rst = utfjson.dump(blk)
+        expected = '{"is_del": 0, "range": ["0a", "0b"], "block_id": "d0g0006400000001230000c62d8736c72800020000000001", "size": 1000}'
+
+        self.assertEqual(expected, rst)
+        loaded = ectypes.BlockDesc(utfjson.load(rst))
+        self.assertEqual(blk, loaded)

--- a/ectypes/test/test_block_id.py
+++ b/ectypes/test/test_block_id.py
@@ -23,15 +23,14 @@ class TestBlockID(unittest.TestCase):
 
         self.assertEqual('d1', bid.type)
         self.assertEqual('g000630000000123', str(bid.block_group_id))
-        self.assertEqual((1, 1), bid.block_index)
+        self.assertEqual((1, 1), bid.block_index.as_tuple())
         self.assertEqual('0101', str(bid.block_index))
-        self.assertEqual('c62d8736c7280002', bid.drive_id.tostr())
+        self.assertEqual('c62d8736c7280002', bid.drive_id)
         self.assertEqual(1, bid.block_id_seq)
 
         # test invalid input
         block_id_invalid = 'd1g0006300000001230101c62d8736c728000200000'
-        self.assertRaises(ectypes.BlockIDError,
-                          ectypes.BlockID.parse, block_id_invalid)
+        self.assertRaises(ValueError, ectypes.BlockID.parse, block_id_invalid)
 
     def test_print(self):
 
@@ -41,9 +40,7 @@ class TestBlockID(unittest.TestCase):
 
         self.assertEqual(block_id, str(bid))
         self.assertEqual(block_id, '{0}'.format(bid))
-        self.assertEqual(
-            "_BlockID(type='d1', block_group_id=_BlockGroupID(block_size=63, seq=123), block_index=_BlockIndex(i=1, j=1), drive_id=_DriveID(server_id='c62d8736c728', mountpoint_index=2), block_id_seq=1)",
-            repr(bid))
+        self.assertEqual("'d1g0006300000001230101c62d8736c72800020000000001'", repr(bid))
 
     def test_new(self):
 
@@ -62,10 +59,8 @@ class TestBlockID(unittest.TestCase):
         block_id = 'd1g0006300000001230101c62d8736c72800020000000001'
         bid = ectypes.BlockID.parse(block_id)
 
-        self.assertEqual(block_id, bid.tostr())
         self.assertEqual(block_id, str(bid))
 
         self.assertIsInstance(bid.drive_id, ectypes.DriveID)
         self.assertEqual('c62d8736c7280002', str(bid.drive_id))
-        self.assertEqual('c62d8736c7280002', bid.drive_id.tostr())
         self.assertEqual('c62d8736c728', bid.drive_id.server_id)

--- a/ectypes/test/test_block_index.py
+++ b/ectypes/test/test_block_index.py
@@ -24,7 +24,7 @@ class TestBlockIndex(unittest.TestCase):
         )
 
         for bad in cases:
-            self.assertRaises(ectypes.BlockIndexError, ectypes.BlockIndex.parse, bad)
+            self.assertRaises(ValueError, ectypes.BlockIndex.parse, bad)
 
     def test_parse(self):
 
@@ -41,7 +41,8 @@ class TestBlockIndex(unittest.TestCase):
             dd(expected)
 
             rst = ectypes.BlockIndex.parse(inp)
-            self.assertEqual(expected, rst)
+            self.assertEqual(expected, rst.as_tuple())
+            self.assertEqual(str(inp), str(rst))
 
     def test_new_invalid(self):
 
@@ -54,4 +55,4 @@ class TestBlockIndex(unittest.TestCase):
 
         for i, j in cases:
             dd(i, j)
-            self.assertRaises(ectypes.BlockIndexError, ectypes.BlockIndex, i, j)
+            self.assertRaises(ValueError, ectypes.BlockIndex, i, j)

--- a/ectypes/test/test_idbase.py
+++ b/ectypes/test/test_idbase.py
@@ -3,11 +3,11 @@
 
 import unittest
 
+from pykit import utfjson
 from pykit.ectypes import BlockGroupID
 from pykit.ectypes import BlockID
 from pykit.ectypes import BlockIndex
 from pykit.ectypes import DriveID
-from pykit.ectypes import json_dump
 
 
 def id_str(_id): return '"{s}"'.format(s=str(_id))
@@ -26,11 +26,11 @@ class TestIDBase(unittest.TestCase):
 
         cases = (
             (None, 'null'),
-            (self.block_group_id.tostr(), id_str(self.block_group_id)),
+            (self.block_group_id,   id_str(self.block_group_id)),
 
             (self.block_group_id,   id_str(self.block_group_id)),
             (self.block_id,         id_str(str(self.block_id))),
-            (self.block_index,      id_str(self.block_index.tostr())),
+            (self.block_index,      id_str(self.block_index)),
             (self.drive_id,         id_str(self.drive_id)),
 
             ([self.block_group_id, self.drive_id],
@@ -49,5 +49,19 @@ class TestIDBase(unittest.TestCase):
                                              id_str(self.block_id), id_str(self.drive_id))),
         )
 
-        for obj, excepted in cases:
-            self.assertEqual(json_dump(obj), excepted)
+        for obj, expected in cases:
+            self.assertEqual(expected, utfjson.dump(obj))
+
+    def test_disable_setattr(self):
+
+        with self.assertRaises(TypeError):
+            self.block_group_id.block_size = 0
+
+        with self.assertRaises(TypeError):
+            self.block_id.drive_id = 0
+
+        with self.assertRaises(TypeError):
+            self.block_index.i = 0
+
+        with self.assertRaises(TypeError):
+            self.drive_id.server_id = 0

--- a/ectypes/test/test_region.py
+++ b/ectypes/test/test_region.py
@@ -4,6 +4,7 @@
 import unittest
 
 from pykit import ectypes
+from pykit import utfjson
 from pykit import ututil
 from pykit.ectypes import BlockDesc
 from pykit.ectypes import BlockID
@@ -64,6 +65,20 @@ class TestClusterRegion(unittest.TestCase):
         region = ectypes.Region(
             levels=region_cases_argkv[0][0], range=region_cases_argkv[1][0])
         self.assertEqual(region_cases_argkv[2][1], region)
+
+    def test_json(self):
+        region = ectypes.Region({'range': ['a', 'z'],
+                                 'levels': [
+            [['a', 'b', BlockDesc()],
+             ['b', 'c', BlockDesc(size=2,
+                                  block_id=BlockID.parse('d1g0006300000001230101c62d8736c72800020000000001'))]
+             ]]})
+        rst = utfjson.dump(region)
+        expected = '{"range": ["a", "z"], "levels": [[["a", "b", {"is_del": 0, "range": null, "block_id": null, "size": 0}], ["b", "c", {"is_del": 0, "range": null, "block_id": "d1g0006300000001230101c62d8736c72800020000000001", "size": 2}]]], "idc": ""}'
+        self.assertEqual(expected, rst)
+
+        loaded = ectypes.Region(utfjson.load(rst))
+        self.assertEqual(region, loaded)
 
     def test_move_down(self):
 

--- a/ectypes/test/test_server.py
+++ b/ectypes/test/test_server.py
@@ -43,7 +43,7 @@ class TestClusterServer(unittest.TestCase):
         )
 
         for c in invalid_cases:
-            self.assertFalse(ectypes.ServerID.validate(c))
+            self.assertRaises(ValueError, ectypes.ServerID, c)
 
         cases = (
             '112233aabbcc',
@@ -53,14 +53,13 @@ class TestClusterServer(unittest.TestCase):
         )
 
         for c in cases:
-            self.assertTrue(ectypes.ServerID.validate(c))
+            ectypes.ServerID(c)
 
     def test_server_id_to_str(self):
         sid = ectypes.ServerID.local_server_id()
         self.assertIsInstance(sid, ectypes.ServerID)
         self.assertEqual('%012x' % uuid.getnode(), str(sid))
         self.assertEqual('%012x' % uuid.getnode(), sid)
-        self.assertEqual('%012x' % uuid.getnode(), sid.tostr())
 
     def test_serverrec(self):
         cases = (
@@ -130,13 +129,16 @@ class TestClusterServer(unittest.TestCase):
         )
 
         for sid, mp_idx in cases:
-            drive_id = str(DriveID(sid, mp_idx))
+            drive_id = DriveID.make(sid, mp_idx)
+            self.assertEqual(sid, drive_id.server_id)
+            self.assertEqual('%03d' % mp_idx, drive_id.mountpoint_index)
+            self.assertEqual(mp_idx, int(drive_id.mountpoint_index))
+
             self.assertEqual('%s0%03d' % (sid[:12], mp_idx % 1000),
                              drive_id)
 
             drvid = DriveID.parse(drive_id)
             self.assertEqual(sid, drvid.server_id)
-            self.assertEqual(mp_idx, drvid.mountpoint_index)
             self.assertEqual(drvid, DriveID.parse(drvid))
 
     def test_drive_id_server_id(self):
@@ -148,7 +150,6 @@ class TestClusterServer(unittest.TestCase):
 
             self.assertIsInstance(drive_id.server_id, str)
             self.assertEqual('112233445566', drive_id.server_id)
-            self.assertEqual('1122334455660001', drive_id.tostr())
             self.assertEqual('1122334455660001', str(drive_id))
 
     def test_validate_drive_id(self):
@@ -166,7 +167,8 @@ class TestClusterServer(unittest.TestCase):
         )
 
         for c in invalid_cases:
-            self.assertFalse(ectypes.DriveID.validate(c))
+            dd(c)
+            self.assertRaises(ValueError, ectypes.DriveID, c)
 
         cases = (
             'aabbccddeeff0001',
@@ -177,7 +179,7 @@ class TestClusterServer(unittest.TestCase):
         )
 
         for c in cases:
-            self.assertTrue(ectypes.DriveID.validate(c))
+            ectypes.DriveID(c)
 
     def test_validate_idc(self):
         invalid_cases = (

--- a/zktx/redisaccessor.py
+++ b/zktx/redisaccessor.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from pykit.ectypes import json_dump
-from pykit.ectypes import json_load
+from pykit import utfjson
 
 
 class RedisKeyValue(object):
@@ -20,7 +19,7 @@ class RedisKeyValue(object):
 
     def set(self, key, value):
         key = self._get_path(key)
-        value = json_dump(value)
+        value = utfjson.dump(value)
         self.cli.set(key, value)
 
     def get(self, key):
@@ -30,7 +29,7 @@ class RedisKeyValue(object):
         if self.load is not None:
             return self.load(val)
 
-        return json_load(val)
+        return utfjson.load(val)
 
     def hget(self, hashname, hashkey):
         hashkey = self._get_path(hashkey)
@@ -39,11 +38,11 @@ class RedisKeyValue(object):
         if self.load is not None:
             return self.load(val)
 
-        return json_load(val)
+        return utfjson.load(val)
 
     def hset(self, hashname, hashkey, value):
         hashkey = self._get_path(hashkey)
-        value = json_dump(value)
+        value = utfjson.dump(value)
         self.cli.hset(hashname, hashkey, value)
 
 

--- a/zktx/redisstorage.py
+++ b/zktx/redisstorage.py
@@ -5,7 +5,7 @@ import logging
 
 from pykit import config
 from pykit import rangeset
-from pykit.cluster import json_load
+from pykit import utfjson
 
 from .redisaccessor import RedisKeyValue
 from .redisaccessor import RedisValue
@@ -67,7 +67,7 @@ class RedisStorage(Storage):
 
 
 def txidset_load(value):
-    val = json_load(value)
+    val = utfjson.load(value)
     if val is None:
         val = {}
 

--- a/zktx/zkstorage.py
+++ b/zktx/zkstorage.py
@@ -7,8 +7,7 @@ from kazoo.exceptions import BadVersionError
 
 from pykit import rangeset
 from pykit import zkutil
-from pykit.ectypes import json_dump
-from pykit.ectypes import json_load
+from pykit import utfjson
 
 from .status import STATUS
 from .storage import Storage
@@ -65,14 +64,14 @@ class ZKStorage(Storage):
         else:
             keylock.close()
 
-        return locked, json_load(txid), ver
+        return locked, utfjson.load(txid), ver
 
     def _make_key_lock(self, txid, key):
         keylock = zkutil.ZKLock(key,
                                 zkclient=self.zke,
                                 zkconf=self.zke._zkconf,
                                 ephemeral=False,
-                                identifier=json_dump(txid))
+                                identifier=utfjson.dump(txid))
 
         return keylock
 

--- a/zktx/zktx.py
+++ b/zktx/zktx.py
@@ -13,7 +13,7 @@ from kazoo.exceptions import NoNodeError
 
 from pykit import rangeset
 from pykit import zkutil
-from pykit.cluster import json_dump
+from pykit import utfjson
 
 from .exceptions import ConnectionLoss
 from .exceptions import Deadlock
@@ -399,10 +399,10 @@ class ZKTransaction(object):
 
             if curr.version == -1:
                 kazootx.create(cnf.record(rec.k),
-                               json_dump(record_vals))
+                               utfjson.dump(record_vals))
             else:
                 kazootx.set_data(cnf.record(rec.k),
-                                 json_dump(record_vals),
+                                 utfjson.dump(record_vals),
                                  version=curr.version)
 
         state, ver = self._get_state(self.txid)
@@ -413,7 +413,7 @@ class ZKTransaction(object):
             kazootx.delete(cnf.lock(key), version=0)
 
         if len(jour) > 0 or force:
-            kazootx.create(cnf.journal(self.txid), json_dump(jour))
+            kazootx.create(cnf.journal(self.txid), utfjson.dump(jour))
             kazootx.commit()
             status = COMMITTED
         else:


### PR DESCRIPTION
-   Remove validate(), use constructor to check.

-   Simplified xxIDError by using `ValueError`.

-   Remove json_dump() json_load(); Because now xxID is based on `str`
    instead of `namedtuple`, thus json.load and dump works fine with xxID.

-   Remove all tostr(). They are themselves are strings now.

-   Add `as_tuple()` method to all xxID classes.

-   Simplify make/parse method pairs: Now a constructor such as
    `BlockID` do both make and parse:

    -   If there is only one arg, do parse: create a xxID instance from string.

    -   If there are more than one arg, do make: create a xxID instance
        from specified attributes.

    E.g. these tow bid are the same:
    ```
    # make
    bid = BlockID('d0',
                  'g000640000000123',
                  '0000',
                  DriveID('c62d8736c7280002'),
                  1)
    # parse
    bid = BlockID("d0" "g000640000000123" "0000", "c62d8736c7280002" "0000000001")
    ```

    **`make()` and `parse()` are deprecated since this commit.**

-   Add test of json load and dump.