### PR TITLE
move definition of referrer and needle_source

### DIFF
--- a/ectypes/needle_source.py
+++ b/ectypes/needle_source.py
@@ -7,6 +7,8 @@ from referrer import Referrer
 
 class NeedleSource(FixedKeysDict):
 
+    # referrers must be added in non-descending order
+
     keys_default = dict((('NeedleID', str),
                          ('Referrers', list),
                          ('Size', int),
@@ -24,12 +26,18 @@ class NeedleSource(FixedKeysDict):
 
     def add_referrer(self, referrer):
 
+        # before the new referrers is added into the Referrers,the Referrers
+        # are sorted fot they are imported from phy
+
         if not isinstance(referrer, Referrer):
             raise ValueError('referrer is not type Referrer')
 
         if len(self['Referrers']) > 1:
 
             last_ref = self['Referrers'][-1]
+
+            if referrer < last_ref:
+                raise ValueError('referrer is not added in non-descending order')
 
             if last_ref.is_pair(referrer):
                 if self.reserve_del:

--- a/ectypes/needle_source.py
+++ b/ectypes/needle_source.py
@@ -7,8 +7,6 @@ from referrer import Referrer
 
 class NeedleSource(FixedKeysDict):
 
-    # referrers must be added in non-decending order
-
     keys_default = dict((('NeedleID', str),
                          ('Referrers', list),
                          ('Size', int),
@@ -26,18 +24,12 @@ class NeedleSource(FixedKeysDict):
 
     def add_referrer(self, referrer):
 
-        # the Referrers are sorted before a new referrer is added into the
-        # needlesource for the Referrers are imported from phy
-
         if not isinstance(referrer, Referrer):
             raise ValueError('referrer is not type Referrer')
 
         if len(self['Referrers']) > 1:
 
             last_ref = self['Referrers'][-1]
-
-            if referrer.__lt__(last_ref) and last_ref.is_pair(referrer) == 0:
-                return
 
             if last_ref.is_pair(referrer):
                 if self.reserve_del:

--- a/ectypes/needle_source.py
+++ b/ectypes/needle_source.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+from pykit.dictutil import FixedKeysDict
+from referrer import Referrer
+
+
+class NeedleSource(FixedKeysDict):
+
+    # referrers must be added in non-decending order
+
+    keys_default = dict((('NeedleID', str),
+                         ('Referrers', list),
+                         ('Size', int),
+                         ('Url', str),))
+    ident_keys = ('NeedleID',)
+
+    def __init__(self, *args, **argkv):
+
+        self.reserve_del = True
+
+        super(NeedleSource, self).__init__(*args, **argkv)
+
+    def __lt__(self, another):
+        return self.ident() < another.ident()
+
+    def add_referrer(self, referrer):
+
+        # the Referrers are sorted before a new referrer is added into the
+        # needlesource for the Referrers are imported from phy
+
+        if not isinstance(referrer, Referrer):
+            raise ValueError('referrer is not type Referrer')
+
+        if len(self['Referrers']) > 1:
+
+            last_ref = self['Referrers'][-1]
+
+            if referrer.__lt__(last_ref) and last_ref.is_pair(referrer) == 0:
+                return
+
+            if last_ref.is_pair(referrer):
+                if self.reserve_del:
+                    ref = Referrer(self['Referrers'][-1])
+                    ref['IsDel'] = 1
+                    self['Referrers'][-1] = ref
+                else:
+                    del self['Referrers'][-1]
+                return
+
+        if not self.reserve_del and referrer['IsDel'] == 1:
+            return
+
+        self['Referrers'].append(referrer)
+
+    def needle_id_equal(self, another):
+        return self.ident() == another.ident()

--- a/ectypes/referrer.py
+++ b/ectypes/referrer.py
@@ -1,0 +1,37 @@
+#!/usr/bin/ env python2
+# coding: utf-8
+
+from pykit.dictutil import FixedKeysDict
+
+
+class Referrer(FixedKeysDict):
+
+    keys_default = dict((('Scope', str),
+                         ('RefKey', str),
+                         ('Ver', int),
+                         ('IsDel', int),))
+    ident_keys = ('Scope', 'RefKey', 'Ver', 'IsDel',)
+
+    def __eq__(self, b):
+        return self.ident() == b.ident()
+
+    def __ne__(self, b):
+        return self.ident() != b.ident()
+
+    def __ge__(self, b):
+        return self.ident() >= b.ident()
+
+    def __gt__(self, b):
+        return self.ident() > b.ident()
+
+    def __le__(self, b):
+        return self.ident() <= b.ident()
+
+    def __lt__(self, b):
+        return self.ident() < b.ident()
+
+    def is_pair(self, b):
+        a = self
+
+        return (a.ident()[:3] == b.ident()[:3]
+                and set([a['IsDel'], b['IsDel']]) == set([0, 1]))

--- a/ectypes/referrer.py
+++ b/ectypes/referrer.py
@@ -32,6 +32,5 @@ class Referrer(FixedKeysDict):
 
     def is_pair(self, b):
         a = self
-
         return (a.ident()[:3] == b.ident()[:3]
                 and set([a['IsDel'], b['IsDel']]) == set([0, 1]))

--- a/ectypes/test/test_needle_source.py
+++ b/ectypes/test/test_needle_source.py
@@ -36,7 +36,6 @@ n2 = needle_source.NeedleSource({
         'NeedleID': '0',
         'Referrers': [
             _make_referrer('3copy', 'key1', 123, 1),
-
             _make_referrer('3copy', 'key2', 123, 1),
             _make_referrer('3copy', 'key3', 1234, 1),
         ],
@@ -71,7 +70,7 @@ ref2 = referrer.Referrer(Scope="3copy", RefKey="key4", Ver=1243, IsDel=1)
 ref3 = referrer.Referrer(Scope="3copy", RefKey="key5", Ver=123, IsDel=0)
 ref4 = referrer.Referrer(Scope="3copy", RefKey="key6", Ver=123, IsDel=0)
 ref5 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=0)
-ref6 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=1234, IsDel=0)
+ref6 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=0)
 ref7 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=12345, IsDel=1)
 ref8 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=12345, IsDel=1)
 list_test = [1, 2, 3, 4, ]
@@ -81,9 +80,13 @@ class TestNeedleSource(unittest.TestCase):
 
     def test_lt(self):
         self.assertTrue(n0.__lt__(n1))
+        self.assertTrue(n0 < n1)
         self.assertFalse(n0.__lt__(n2))
+        self.assertFalse(n0 < n2)
         self.assertFalse(n0.__lt__(n3))
+        self.assertFalse(n0 < n3)
         self.assertFalse(n0.__lt__(n4))
+        self.assertFalse(n0 < n4)
 
     def test_needle_id_equal(self):
         self.assertFalse(n0.needle_id_equal(n1))
@@ -101,17 +104,13 @@ class TestNeedleSource(unittest.TestCase):
         n0.add_referrer(ref3)
         self.assertIs(len(n0['Referrers']), 6)
 
-        n1.add_referrer(ref8)
-        self.assertIs(len(n1['Referrers']), 3)
         n1.add_referrer(ref7)
-        self.assertTrue(n1['Referrers'][-1].__eq__(ref7))
+        self.assertTrue(n1['Referrers'][-1] == ref7)
         self.assertRaises(ValueError, n1.add_referrer, list_test)
 
         n4.add_referrer(ref4)
         self.assertIs(len(n4['Referrers']), 2)
-        n4.add_referrer(ref5)
-        self.assertIs(len(n4['Referrers']), 1)
         n4.add_referrer(ref6)
-        self.assertIs(len(n4['Referrers']), 2)
-        n4.add_referrer(ref7)
-        self.assertIs(len(n4['Referrers']), 2)
+        self.assertIs(len(n4['Referrers']), 1)
+        n4.add_referrer(ref8)
+        self.assertIs(len(n4['Referrers']), 1)

--- a/ectypes/test/test_needle_source.py
+++ b/ectypes/test/test_needle_source.py
@@ -17,7 +17,7 @@ n0 = needle_source.NeedleSource({
         'Referrers': [
             _make_referrer('3copy', 'key1', 123, 0),
             _make_referrer('3copy', 'key2', 123, 1),
-            _make_referrer('3copy', 'key3', 123, 1),
+            _make_referrer('3copy', 'key3', 123, 0),
         ],
         'Size': 10,
         'Url': '/'
@@ -25,7 +25,7 @@ n0 = needle_source.NeedleSource({
 n1 = needle_source.NeedleSource({
         'NeedleID': '123',
         'Referrers': [
-            _make_referrer('2copy', 'key1', 123, 1),
+            _make_referrer('3copy', 'key1', 123, 1),
             _make_referrer('3copy', 'key2', 123, 1),
             _make_referrer('3copy', 'key3', 123, 0),
         ],
@@ -56,23 +56,25 @@ n4 = needle_source.NeedleSource({
         'NeedleID': '1',
         'Referrers': [
             _make_referrer('3copy', 'key1', 123, 1),
-            _make_referrer('3copy', 'key3', 123, 1),
-            _make_referrer('3copy', 'key6', 123, 1),
+            _make_referrer('3copy', 'key3', 123, 0),
+            _make_referrer('3copy', 'key6', 123, 0),
         ],
         'Size': 10,
         'Url': '/'
     })
 n4.reserve_del = False
 
-ref0 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=0)
+ref0 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=1)
 ref1 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=1234, IsDel=0)
 ref2 = referrer.Referrer(Scope="3copy", RefKey="key4", Ver=1243, IsDel=1)
 ref3 = referrer.Referrer(Scope="3copy", RefKey="key5", Ver=123, IsDel=0)
-ref4 = referrer.Referrer(Scope="3copy", RefKey="key6", Ver=123, IsDel=0)
-ref5 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=0)
-ref6 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=0)
+ref4 = referrer.Referrer(Scope="3copy", RefKey="key6", Ver=123, IsDel=1)
+ref5 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=1)
+ref6 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=1234, IsDel=1)
 ref7 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=12345, IsDel=1)
 ref8 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=12345, IsDel=1)
+ref9 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=123456, IsDel=1)
+ref10 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=1234567, IsDel=0)
 list_test = [1, 2, 3, 4, ]
 
 
@@ -111,6 +113,10 @@ class TestNeedleSource(unittest.TestCase):
         n4.add_referrer(ref4)
         self.assertIs(len(n4['Referrers']), 2)
         n4.add_referrer(ref6)
+        self.assertIs(len(n4['Referrers']), 2)
+        n4.add_referrer(ref5)
         self.assertIs(len(n4['Referrers']), 1)
-        n4.add_referrer(ref8)
+        n4.add_referrer(ref9)
         self.assertIs(len(n4['Referrers']), 1)
+        n4.add_referrer(ref10)
+        self.assertIs(len(n4['Referrers']), 2)

--- a/ectypes/test/test_needle_source.py
+++ b/ectypes/test/test_needle_source.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+import unittest
+
+from pykit.ectypes import referrer
+from pykit.ectypes import needle_source
+
+
+def _make_referrer(scope, refkey, ver, is_del):
+    return referrer.Referrer(Scope=scope,
+                             RefKey=refkey, Ver=ver, IsDel=is_del)
+
+
+n0 = needle_source.NeedleSource({
+        'NeedleID': '1',
+        'Referrers': [
+            _make_referrer('3copy', 'key1', 123, 0),
+            _make_referrer('3copy', 'key2', 123, 1),
+            _make_referrer('3copy', 'key3', 123, 1),
+        ],
+        'Size': 10,
+        'Url': '/'
+    })
+n1 = needle_source.NeedleSource({
+        'NeedleID': '123',
+        'Referrers': [
+            _make_referrer('2copy', 'key1', 123, 1),
+            _make_referrer('3copy', 'key2', 123, 1),
+            _make_referrer('3copy', 'key3', 123, 0),
+        ],
+        'Size': 10,
+        'Url': '/'
+    })
+n2 = needle_source.NeedleSource({
+        'NeedleID': '0',
+        'Referrers': [
+            _make_referrer('3copy', 'key1', 123, 1),
+
+            _make_referrer('3copy', 'key2', 123, 1),
+            _make_referrer('3copy', 'key3', 1234, 1),
+        ],
+        'Size': 10,
+        'Url': '/'
+    })
+n3 = needle_source.NeedleSource({
+        'NeedleID': '1',
+        'Referrers': [
+            _make_referrer('3copy', 'key1', 123, 1),
+            _make_referrer('3copy', 'key2', 123, 1),
+            _make_referrer('3copy', 'key3', 123, 1),
+        ],
+        'Size': 10,
+        'Url': '/'
+    })
+n4 = needle_source.NeedleSource({
+        'NeedleID': '1',
+        'Referrers': [
+            _make_referrer('3copy', 'key1', 123, 1),
+            _make_referrer('3copy', 'key3', 123, 1),
+            _make_referrer('3copy', 'key6', 123, 1),
+        ],
+        'Size': 10,
+        'Url': '/'
+    })
+n4.reserve_del = False
+
+ref0 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=0)
+ref1 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=1234, IsDel=0)
+ref2 = referrer.Referrer(Scope="3copy", RefKey="key4", Ver=1243, IsDel=1)
+ref3 = referrer.Referrer(Scope="3copy", RefKey="key5", Ver=123, IsDel=0)
+ref4 = referrer.Referrer(Scope="3copy", RefKey="key6", Ver=123, IsDel=0)
+ref5 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=123, IsDel=0)
+ref6 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=1234, IsDel=0)
+ref7 = referrer.Referrer(Scope="3copy", RefKey="key3", Ver=12345, IsDel=1)
+ref8 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=12345, IsDel=1)
+list_test = [1, 2, 3, 4, ]
+
+
+class TestNeedleSource(unittest.TestCase):
+
+    def test_lt(self):
+        self.assertTrue(n0.__lt__(n1))
+        self.assertFalse(n0.__lt__(n2))
+        self.assertFalse(n0.__lt__(n3))
+        self.assertFalse(n0.__lt__(n4))
+
+    def test_needle_id_equal(self):
+        self.assertFalse(n0.needle_id_equal(n1))
+        self.assertFalse(n0.needle_id_equal(n2))
+        self.assertTrue(n0.needle_id_equal(n3))
+        self.assertTrue(n0.needle_id_equal(n4))
+
+    def test_add_referrer(self):
+        n0.add_referrer(ref0)
+        self.assertIs(len(n0['Referrers']), 3)
+        n0.add_referrer(ref1)
+        self.assertIs(len(n0['Referrers']), 4)
+        n0.add_referrer(ref2)
+        self.assertIs(len(n0['Referrers']), 5)
+        n0.add_referrer(ref3)
+        self.assertIs(len(n0['Referrers']), 6)
+
+        n1.add_referrer(ref8)
+        self.assertIs(len(n1['Referrers']), 3)
+        n1.add_referrer(ref7)
+        self.assertTrue(n1['Referrers'][-1].__eq__(ref7))
+        self.assertRaises(ValueError, n1.add_referrer, list_test)
+
+        n4.add_referrer(ref4)
+        self.assertIs(len(n4['Referrers']), 2)
+        n4.add_referrer(ref5)
+        self.assertIs(len(n4['Referrers']), 1)
+        n4.add_referrer(ref6)
+        self.assertIs(len(n4['Referrers']), 2)
+        n4.add_referrer(ref7)
+        self.assertIs(len(n4['Referrers']), 2)

--- a/ectypes/test/test_needle_source.py
+++ b/ectypes/test/test_needle_source.py
@@ -109,6 +109,7 @@ class TestNeedleSource(unittest.TestCase):
         n1.add_referrer(ref7)
         self.assertTrue(n1['Referrers'][-1] == ref7)
         self.assertRaises(ValueError, n1.add_referrer, list_test)
+        self.assertRaises(ValueError, n1.add_referrer, ref8)
 
         n4.add_referrer(ref4)
         self.assertIs(len(n4['Referrers']), 2)

--- a/ectypes/test/test_referrer.py
+++ b/ectypes/test/test_referrer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 # coding: utf-8
 
 import unittest
@@ -24,39 +24,63 @@ ref15 = referrer.Referrer(Scope="3copy", RefKey="key2", Ver=12, IsDel=0)
 class TestReferrer(unittest.TestCase):
     def test_eq(self):
         self.assertFalse(ref1.__eq__(ref2))
+        self.assertFalse(ref1 == ref2)
         self.assertFalse(ref1.__eq__(ref3))
+        self.assertFalse(ref1 == ref3)
         self.assertFalse(ref1.__eq__(ref4))
+        self.assertFalse(ref1 == ref4)
         self.assertTrue(ref1.__eq__(ref5))
+        self.assertTrue(ref1 == ref5)
 
     def test_ne(self):
         self.assertTrue(ref1.__ne__(ref6))
+        self.assertTrue(ref1 != ref6)
         self.assertTrue(ref6.__ne__(ref7))
+        self.assertTrue(ref6 != ref7)
         self.assertTrue(ref1.__ne__(ref8))
+        self.assertTrue(ref1 != ref8)
         self.assertFalse(ref1.__ne__(ref5))
+        self.assertFalse(ref1 != ref5)
 
     def test_ge(self):
         self.assertFalse(ref1.__ge__(ref3))
+        self.assertFalse(ref1 >= ref3)
         self.assertFalse(ref1.__ge__(ref6))
+        self.assertFalse(ref1 >= ref6)
         self.assertTrue(ref1.__ge__(ref9))
+        self.assertTrue(ref1 >= ref9)
         self.assertTrue(ref5.__ge__(ref1))
+        self.assertTrue(ref5 >= ref1)
 
     def test_gt(self):
         self.assertTrue(ref1.__gt__(ref2))
+        self.assertTrue(ref1 > ref2)
         self.assertFalse(ref1.__gt__(ref6))
+        self.assertFalse(ref1 > ref6)
         self.assertFalse(ref10.__gt__(ref1))
+        self.assertFalse(ref10 > ref1)
         self.assertFalse(ref5.__gt__(ref1))
+        self.assertFalse(ref5 > ref1)
 
     def test_le(self):
         self.assertTrue(ref1.__le__(ref7))
+        self.assertTrue(ref1 <= ref7)
         self.assertFalse(ref1.__le__(ref11))
+        self.assertFalse(ref1 <= ref11)
         self.assertFalse(ref1.__le__(ref12))
+        self.assertFalse(ref1 <= ref12)
         self.assertTrue(ref5.__le__(ref1))
+        self.assertTrue(ref5 <= ref1)
 
     def test_lt(self):
         self.assertTrue(ref1.__lt__(ref13))
+        self.assertTrue(ref1 < ref13)
         self.assertFalse(ref1.__lt__(ref14))
+        self.assertFalse(ref1 < ref14)
         self.assertTrue(ref1.__lt__(ref15))
+        self.assertTrue(ref1 < ref15)
         self.assertFalse(ref1.__lt__(ref5))
+        self.assertFalse(ref1 < ref5)
 
     def test_ispair(self):
         self.assertFalse(ref1.is_pair(ref6))

--- a/ectypes/test/test_referrer.py
+++ b/ectypes/test/test_referrer.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import unittest
+from pykit.ectypes import referrer
+
+ref1 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=123, IsDel=0)
+ref2 = referrer.Referrer(Scope="2copy", RefKey="key1", Ver=123, IsDel=0)
+ref3 = referrer.Referrer(Scope="3copy", RefKey="key2", Ver=123, IsDel=0)
+ref4 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=124, IsDel=1)
+ref5 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=123, IsDel=0)
+ref6 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=1234, IsDel=0)
+ref7 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=123, IsDel=1)
+ref8 = referrer.Referrer(Scope="2copy", RefKey="key2", Ver=143, IsDel=0)
+ref9 = referrer.Referrer(Scope="2copy", RefKey="key1", Ver=1234, IsDel=0)
+ref10 = referrer.Referrer(Scope="2copy", RefKey="key1", Ver=124, IsDel=0)
+ref11 = referrer.Referrer(Scope="2copy", RefKey="key2", Ver=123, IsDel=0)
+ref12 = referrer.Referrer(Scope="2copy", RefKey="key2", Ver=124, IsDel=1)
+ref13 = referrer.Referrer(Scope="3copy", RefKey="key12", Ver=123, IsDel=0)
+ref14 = referrer.Referrer(Scope="3copy", RefKey="key1", Ver=12, IsDel=1)
+ref15 = referrer.Referrer(Scope="3copy", RefKey="key2", Ver=12, IsDel=0)
+
+
+class TestReferrer(unittest.TestCase):
+    def test_eq(self):
+        self.assertFalse(ref1.__eq__(ref2))
+        self.assertFalse(ref1.__eq__(ref3))
+        self.assertFalse(ref1.__eq__(ref4))
+        self.assertTrue(ref1.__eq__(ref5))
+
+    def test_ne(self):
+        self.assertTrue(ref1.__ne__(ref6))
+        self.assertTrue(ref6.__ne__(ref7))
+        self.assertTrue(ref1.__ne__(ref8))
+        self.assertFalse(ref1.__ne__(ref5))
+
+    def test_ge(self):
+        self.assertFalse(ref1.__ge__(ref3))
+        self.assertFalse(ref1.__ge__(ref6))
+        self.assertTrue(ref1.__ge__(ref9))
+        self.assertTrue(ref5.__ge__(ref1))
+
+    def test_gt(self):
+        self.assertTrue(ref1.__gt__(ref2))
+        self.assertFalse(ref1.__gt__(ref6))
+        self.assertFalse(ref10.__gt__(ref1))
+        self.assertFalse(ref5.__gt__(ref1))
+
+    def test_le(self):
+        self.assertTrue(ref1.__le__(ref7))
+        self.assertFalse(ref1.__le__(ref11))
+        self.assertFalse(ref1.__le__(ref12))
+        self.assertTrue(ref5.__le__(ref1))
+
+    def test_lt(self):
+        self.assertTrue(ref1.__lt__(ref13))
+        self.assertFalse(ref1.__lt__(ref14))
+        self.assertTrue(ref1.__lt__(ref15))
+        self.assertFalse(ref1.__lt__(ref5))
+
+    def test_ispair(self):
+        self.assertFalse(ref1.is_pair(ref6))
+        self.assertFalse(ref1.is_pair(ref11))
+        self.assertFalse(ref1.is_pair(ref5))
+        self.assertTrue(ref1.is_pair(ref7))


### PR DESCRIPTION
### 将ec中的referrer和needle_source的定义迁移到pykit的ectypes下，并完成了相关测试
>- referrer和needle_source的定义分别进行了迁移，分别位于ectypes下的referrer.py
>- 和needle_source.py下
>- 编写了referrer和needle_source的单元测试
