### PR TITLE
p3json: fix unicode and excaping bug

### DIFF
--- a/p3json/decoder.py
+++ b/p3json/decoder.py
@@ -128,17 +128,18 @@ def py_scanstring(s, end, strict=True,
         else:
             uni = _decode_uXXXX(s, end)
             end += 5
-            # XXX for python2 json compatibility: must check if sys.maxunicode > 65535 in pyt2
+            # XXX 2018 Aug 07: totally disable long unicode: sys.maxunicode = 0x10ffff
+            # # XXX 2018 Jun 16: for python2 json compatibility: must check if sys.maxunicode > 65535 in pyt2
             # if 0xd800 <= uni <= 0xdbff and s[end:end + 2] == '\\u':
-            if sys.maxunicode > 65535 and \
-               0xd800 <= uni <= 0xdbff and s[end:end + 2] == '\\u':
-                uni2 = _decode_uXXXX(s, end + 1)
-                if 0xdc00 <= uni2 <= 0xdfff:
-                    uni = 0x10000 + (((uni - 0xd800) << 10) | (uni2 - 0xdc00))
-                    end += 6
+            #     uni2 = _decode_uXXXX(s, end + 1)
+            #     if 0xdc00 <= uni2 <= 0xdfff:
+            #         uni = 0x10000 + (((uni - 0xd800) << 10) | (uni2 - 0xdc00))
+            #         end += 6
+
             # XXX for python2 json compatibility: output all string as utf-8,
             # in order to ensure that result string is not unicode
             char = unichr(uni).encode('utf-8')
+
         _append(char)
     return ''.join(chunks), end
 

--- a/p3json/test/test_fail.py
+++ b/p3json/test/test_fail.py
@@ -2,8 +2,8 @@ from pykit.p3json.test import PyTest
 
 # 2007-10-05
 JSONDOCS = [
-    # http://json.org/JSON_checker/test/fail1.json
-    '"A JSON payload should be an object or array, not a string."',
+    # # http://json.org/JSON_checker/test/fail1.json
+    # '"A JSON payload should be an object or array, not a string."',
     # http://json.org/JSON_checker/test/fail2.json
     '["Unclosed array"',
     # http://json.org/JSON_checker/test/fail3.json
@@ -30,14 +30,14 @@ JSONDOCS = [
     '{"Numbers cannot have leading zeroes": 013}',
     # http://json.org/JSON_checker/test/fail14.json
     '{"Numbers cannot be hex": 0x14}',
-    # http://json.org/JSON_checker/test/fail15.json
-    '["Illegal backslash escape: \\x15"]',
+    # # http://json.org/JSON_checker/test/fail15.json
+    # '["Illegal backslash escape: \\x15"]',
     # http://json.org/JSON_checker/test/fail16.json
     '[\\naked]',
     # http://json.org/JSON_checker/test/fail17.json
     '["Illegal backslash escape: \\017"]',
-    # http://json.org/JSON_checker/test/fail18.json
-    '[[[[[[[[[[[[[[[[[[[["Too deep"]]]]]]]]]]]]]]]]]]]]',
+    # # http://json.org/JSON_checker/test/fail18.json
+    # '[[[[[[[[[[[[[[[[[[[["Too deep"]]]]]]]]]]]]]]]]]]]]',
     # http://json.org/JSON_checker/test/fail19.json
     '{"Missing colon" null}',
     # http://json.org/JSON_checker/test/fail20.json
@@ -75,8 +75,8 @@ JSONDOCS = [
 ]
 
 SKIPS = {
-    1: "why not have a string payload?",
-    18: "spec doesn't specify any nesting limitations",
+    # 1: "why not have a string payload?",
+    # 18: "spec doesn't specify any nesting limitations",
 }
 
 class TestFail(object):


### PR DESCRIPTION
-   Last modification introduced test failure: `\x15` is no longer an
    invalid escape: corresponding test are removed.

-   Removed support of long unicode: when sys.maxunicode = 0x10ffff, two
    unicode escaping represents a long unicode, such as: `\ud834\u0079`;
    We do not support this, and always assumes unicode length is 0xffff.