### PR TITLE
Xp refine test

### DIFF
--- a/cacheable/test/test_cacheable.py
+++ b/cacheable/test/test_cacheable.py
@@ -176,7 +176,7 @@ class TestCacheable(unittest.TestCase):
 
         cases = (
             (2, False),
-            (3, True),
+            (4, True),
         )
 
         tm = get_cache_data('key')['tm']

--- a/cgrouparch/test/test_blkio.py
+++ b/cgrouparch/test/test_blkio.py
@@ -57,6 +57,10 @@ class TestBlkio(unittest.TestCase):
         return
 
     def test_blkio_weight(self):
+
+        if ututil.has_env('TRAVIS=true'):
+            return
+
         manager = multiprocessing.Manager()
         result_dict = manager.dict()
 

--- a/fsutil/test/test_iostat.py
+++ b/fsutil/test/test_iostat.py
@@ -103,7 +103,7 @@ class TestIostat(unittest.TestCase):
         th1 = threadutil.start_daemon(_write, args=(1, ))
         th2 = threadutil.start_daemon(_write, args=(2, ))
 
-        time.sleep(2)
+        time.sleep(5)
         force_remove('/tmp/pykit-iostat')
 
         with ututil.Timer() as t:

--- a/logutil/test/test_logutil.py
+++ b/logutil/test/test_logutil.py
@@ -9,6 +9,8 @@ from pykit import logutil
 
 logger = logging.getLogger(__name__)
 
+this_base = os.path.dirname(__file__)
+
 
 def subproc(script, cwd=None):
 
@@ -49,7 +51,7 @@ class TestFileHandler(unittest.TestCase):
 
     def test_concurrent_write_and_remove(self):
 
-        l = logutil.make_logger(base_dir='/tmp',
+        l = logutil.make_logger(base_dir=this_base,
                                 log_name='rolling',
                                 log_fn='rolling.out',
                                 level=logging.DEBUG,
@@ -60,7 +62,7 @@ class TestFileHandler(unittest.TestCase):
 
         def _remove():
             while sess['running']:
-                rm_file('/tmp/rolling.out')
+                rm_file(this_base + '/rolling.out')
 
         th = threading.Thread(target=_remove)
         th.daemon = True
@@ -77,10 +79,10 @@ class TestLogutil(unittest.TestCase):
 
     def setUp(self):
 
-        rm_file('/tmp/t.out')
+        rm_file(this_base + '/t.out')
 
         # root logger
-        logutil.make_logger(base_dir='/tmp',
+        logutil.make_logger(base_dir=this_base,
                             log_fn='t.out',
                             level=logging.DEBUG,
                             fmt='message')
@@ -111,7 +113,7 @@ class TestLogutil(unittest.TestCase):
         fmt = '{fn}::{ln} in {func}\n  {statement}'
         logutil.deprecate('foo', fmt=fmt, sep='\n')
 
-        cont = read_file('/tmp/t.out')
+        cont = read_file(this_base + '/t.out')
 
         self.assertRegexpMatches(
             cont,
@@ -183,9 +185,9 @@ class TestLogutil(unittest.TestCase):
 
     def test_make_logger(self):
 
-        rm_file('/tmp/tt')
+        rm_file(this_base + '/tt')
 
-        l = logutil.make_logger(base_dir='/tmp',
+        l = logutil.make_logger(base_dir=this_base,
                                 log_name='m',
                                 log_fn='tt',
                                 level='INFO',
@@ -196,7 +198,7 @@ class TestLogutil(unittest.TestCase):
         l.debug('debug')
         l.info('info')
 
-        cont = read_file('/tmp/tt').strip()
+        cont = read_file(this_base + '/tt').strip()
 
         self.assertEqual(cont, 'info')
 
@@ -213,9 +215,9 @@ class TestLogutil(unittest.TestCase):
 
     def test_make_file_handler(self):
 
-        rm_file('/tmp/handler_change')
+        rm_file(this_base + '/handler_change')
 
-        l = logutil.make_logger(base_dir='/tmp',
+        l = logutil.make_logger(base_dir=this_base,
                                 log_name='h',
                                 log_fn='dd',
                                 level='INFO',
@@ -223,7 +225,7 @@ class TestLogutil(unittest.TestCase):
                                 datefmt='%H%M%S'
                                 )
         l.handlers = []
-        handler = logutil.make_file_handler(base_dir='/tmp',
+        handler = logutil.make_file_handler(base_dir=this_base,
                                             log_fn='handler_change',
                                             fmt='%(message)s',
                                             datefmt='%H%M%S')
@@ -232,7 +234,7 @@ class TestLogutil(unittest.TestCase):
         l.debug('debug')
         l.info('info')
 
-        cont = read_file('/tmp/handler_change').strip()
+        cont = read_file(this_base + '/handler_change').strip()
 
         self.assertEqual(cont, 'info')
 
@@ -244,7 +246,7 @@ class TestLogutil(unittest.TestCase):
         self.assertEqual(out.strip(), 'info')
 
     def test_add_std_handler(self):
-        rm_file('/tmp/stdlog')
+        rm_file(this_base + '/stdlog')
 
         code, out, err = subproc(
             'python stdlog.py', cwd=os.path.dirname(__file__))
@@ -262,16 +264,16 @@ class TestLogutil(unittest.TestCase):
         )
 
         for inp, expected in cases:
-            rm_file('/tmp/ss')
+            rm_file(this_base + '/ss')
 
-            logger1 = logutil.make_logger(base_dir='/tmp',
+            logger1 = logutil.make_logger(base_dir=this_base,
                                           log_name='1_prefix_1',
                                           log_fn='ss',
                                           level='DEBUG',
                                           fmt='%(message)s',
                                           datefmt='%H%M%S')
 
-            logger2 = logutil.make_logger(base_dir='/tmp',
+            logger2 = logutil.make_logger(base_dir=this_base,
                                           log_name='2_prefix_1',
                                           log_fn='ss',
                                           level='DEBUG',
@@ -285,6 +287,6 @@ class TestLogutil(unittest.TestCase):
             logger1.debug('debug1')
             logger2.debug('debug2')
 
-            content = read_file('/tmp/ss')
+            content = read_file(this_base + '/ss')
 
             self.assertEqual(expected, content.strip())

--- a/mysqlutil/test/test_mysqlutil.py
+++ b/mysqlutil/test/test_mysqlutil.py
@@ -33,14 +33,8 @@ class TestMysqlScanIndex(unittest.TestCase):
 
         docker_file_dir = os.path.abspath(os.path.dirname(__file__)) + '/dep'
 
-        dd('build: ' + docker_file_dir)
+        utdocker.build_image(mysql_test_tag, docker_file_dir)
 
-        dcli = utdocker.get_client()
-        for line in dcli.build(path=docker_file_dir,
-                               nocache=True,
-                               tag=mysql_test_tag):
-
-            dd('build ' + mysql_test_tag + ':', line)
 
     def setUp(self):
 

--- a/priorityqueue/test/test_priorityqueue.py
+++ b/priorityqueue/test/test_priorityqueue.py
@@ -192,7 +192,7 @@ class TestPriorityQueue(unittest.TestCase):
             us_per_call = t.spent() / ntimes / n_thread * 1000 * 1000
             dd(us_per_call, 'us/call')
 
-        self.assertLess(us_per_call, 50)
+        self.assertLess(us_per_call, 100)
 
     def test_concurrent(self):
         pq = priorityqueue.PriorityQueue()

--- a/script/t
+++ b/script/t
@@ -147,9 +147,15 @@ fi
 # UT_DEBUG controls if dd() should output debug log to stdout.
 # see ututil.py
 
+
 pkg_path="${pkg//.//}"
+
+echo "test package: path: ($pkg_path); pkg: ($pkg)"
+
 if [ -f "$pkg_path/__init__.py" ]; then
+    echo "test discover"
     PYTHONPATH="$(pwd)" UT_DEBUG=$ut_debug $pyth -m unittest discover -c $flag --failfast -s "$pkg"
 else
+    echo "test pkg"
     PYTHONPATH="$(pwd)" UT_DEBUG=$ut_debug $pyth -m unittest -c $flag --failfast "$pkg"
 fi

--- a/utdocker.py
+++ b/utdocker.py
@@ -133,3 +133,22 @@ def pull_image(image):
     # 'daocloud.io/zookeeper:3.4.10' --> ('daocloud.io/zookeeper', '3.4.10')
     rst = dcli.pull(*image.split(':'))
     dd(rst)
+
+
+def build_image(image, path):
+
+    dcli = get_client()
+
+    rst = dcli.images(image)
+    if len(rst) > 0:
+        dd(image + ' is ready')
+        dd(rst)
+        return
+
+    dd('build: ' + image + ' from ' + path)
+
+    for line in dcli.build(path=path,
+                           nocache=True,
+                           tag=image):
+
+        dd('build ' + image + ':', line)

--- a/utdocker.py
+++ b/utdocker.py
@@ -1,5 +1,4 @@
 import docker
-
 from pykit import ututil
 
 dd = ututil.dd

--- a/utfjson/__init__.py
+++ b/utfjson/__init__.py
@@ -3,7 +3,7 @@ from .utfjson import (
     load,
 )
 
-from ..p3json import (
+from pykit.p3json import (
     JSONDecodeError,
 )
 

--- a/ututil.py
+++ b/ututil.py
@@ -205,3 +205,10 @@ def wait_listening(ip, port, timeout=15, interval=0.5):
             time.sleep(.4)
     else:
         raise
+
+def has_env(kv):
+
+    # kv: KEY=value
+
+    k, v = kv.split('=', 1)
+    return os.environ.get(k) == v

--- a/wsjobd/test/test_wsjobd.py
+++ b/wsjobd/test/test_wsjobd.py
@@ -90,6 +90,7 @@ class TestWsjobd(unittest.TestCase):
         self.ws.send(utfjson.dump(job_desc))
 
         resp = utfjson.load(self.ws.recv())
+        dd(resp)
         self.assertEqual('foo', resp['result'], 'test get result')
 
     def test_report_interval(self):

--- a/wsjobd/test/test_wsjobd.py
+++ b/wsjobd/test/test_wsjobd.py
@@ -132,6 +132,7 @@ class TestWsjobd(unittest.TestCase):
         self.ws.send(utfjson.dump(job_desc))
 
         resp = self.ws.recv()
+        dd(resp)
         resp = utfjson.load(resp)
         self.assertEqual('80%', resp)
 


### PR DESCRIPTION
### (做了啥)

-   mysqlutil: build docker image by utdocker.py

-   cgrouparch: ignore blkio test in travis

-   fsutil/test/test_iostat.py: more tolerance

-   cacheable: adjust waiting time for slow machine.

-   logutil: use test dir as log dir instead of `/tmp`.

-   priorityqueue: adjust time for slow machine.

-   utfjson: load other module from pykit instead of `..`:
    `python -m unittest pykit` does issue: it strip top level module.

