### PR TITLE
design http request and add aws_sign() for add_auth

### DIFF
--- a/request/README.md
+++ b/request/README.md
@@ -52,7 +52,6 @@ dict1 = {
     'headers': {
         'Host': host,
     },
-    'body': '',
     'fields': {
         'key': key_name,
         'Policy': {
@@ -79,7 +78,9 @@ request1 = Request(dict1, data = "file or str")
 # send request
 conn = http.Client(host, port)
 conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
-conn.send_body(request1['body'])
+# request1['body'] is generator type
+for body in request1['body']:
+    conn.send_body(body)
 resp = conn.read_response()
 ```
 
@@ -119,10 +120,9 @@ can be sent directly.
         a python dict contains request headers. It must contain the `Host` header.
 
     -   `body`:
-        a string contains the request payload. In non-post request, If you do
-        not want to sign the payload or you have set `X-Amz-ContentSHA256` header
-        in `headers`, you can omit this field. In post request, when provide a dict,
-        body is empty, body is obtained by the fields,
+        a string contains the request payload. When provide a dict to construct a request,
+        body must be empty. Body is obtained by the fields in post request and is obtained
+        by the data in non post request. Body is str or generator type in our request.
 
     -   `fields`: a python dict which contains form fields. Only the post
         request fields is not empty, other situations fields is empty.

--- a/request/README.md
+++ b/request/README.md
@@ -1,0 +1,194 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+#   Table of Content
+
+- [Name](#name)
+- [Status](#status)
+- [Synopsis](#synopsis)
+
+  - [Request](#request)
+- [Methods](#methods)
+  - [Request.aws_sign](#requestaws_sign)
+- [Author](#author)
+- [Copyright and License](#copyright-and-license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+#   Name
+
+request
+
+represents a http request including a normal request and  an aws version 4 signature request 
+
+#   Status
+
+This library is considered production ready.
+
+#   Synopsis
+
+```python
+bucket_name = 'your bucket name'
+key_name = 'your key'
+endpoint = 'the endpoint'
+
+host = bucket_name + '.' + endpoint
+port = portnumber
+
+access_key = 'your access key'
+secret_key = 'your secret key'
+# create a suitable dict according to verb
+dict1 = {
+    'verb': 'POST',
+    'uri': '/',
+    'args': {},
+    'headers': {
+        'Host': host,
+    },
+    'body': '',
+    'fields': {
+        'key': key_name,
+        'Policy': {
+            'expiration': '2018-09-30T12:00:00.000Z',
+            'conditions': [
+                ['starts-with', '$key', ''],
+                {
+                    'bucket': bucket_name,
+                },
+            ],
+        },
+    },
+    'do_add_auth': 1
+}
+request1 = Request(dict1)
+
+# content can be a file or str in post request
+request1.content = "send post request"
+# whether call function aws_sign() according to 'do_add_auth' value
+request1.aws_sign(access_key, secret_key, request_date='20180917T120101Z')
+# send request
+conn = http.Client(host, port)
+conn.send_request(request1['uri'], method='POST', headers=request1['headers'])
+conn.send_body(request1['body'])
+resp = conn.read_response()
+```
+
+#   Description
+Request represents a http request including a normal request and  an aws version 4 signature request
+You need to provide a python dict which represent your request(it typically contains 'verb',
+'uri', 'args', 'headers', 'body', 'fields', 'do_add_auth'), and your access key and secret key.
+This lib will create a http request and add signature to the request(do_add_auth is True) by call function aws_sign().
+
+#   Classes
+
+## Request
+
+**syntax**
+`request1 = request.Request(dict)`
+
+**argument**
+
+-   `dict`
+    a python dict which used to represent your request.
+    It may contain the following fields:
+
+    -   `verb`:
+        the request method, such as 'GET', 'PUT', 'POST'. Required.
+
+    -   `uri`:
+        the url encoded uri. In PUT/GET request, it can contain query string
+        only when you did not specify `args` in `request`. Required.
+
+    -   `args`:
+        a python dict contains the request parameters, it should not be
+        url encoded. You can not use both `args` and query string in `uri`
+        at the same time. Generally this attribute is null in post request.
+
+    -   `headers`:
+        a python dict contains request headers. It must contains the
+        'Host' header.
+
+    -   `body`:
+        a string contains the request payload. In non-post request, If you do not want to sign
+        the payload or you have set 'X-Amz-ContentSHA256' header in `headers`,
+        you can omit this field. In POST request, when provide a dict, body
+        is null, body is obtained by the fields,
+
+    -   'fields': a python dict which contains form fields. Only the post reqeust the
+        fields is not {}, other situations the value is {}.It may contain the following attributes:
+        
+        -   `Policy`:
+            is python dict, describing what is permitted in POST request.
+            After calling aws_sign() function, it will be replaced by it's base64
+            encoded version.
+
+        -   `key`:
+            the key of the object to upload.
+
+        It also support some other fields, more infomation at
+        [here](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html)
+        This method will add some signature related fields to this dict.
+
+    -   'do_add_auth':
+        a bool number to mark whether the request needs to add auth. When the
+        value is True, the request needs to call the aws_sign() to update the request.
+
+##  Request.aws_sign
+
+The method is used to get a signed request. Only when 'do_add_auth' is True,
+this function can be called.
+
+**syntax**
+`request1.aws_sign(access_key, secret_key, query_auth=query_auth, sign_payload=sign_payload,
+    headers_not_to_sign=headers_not_to_sign, request_date=request_date, signing_date=signing_date,
+    region=region, service=service, expires=expires)`
+
+**arguments**
+
+-   `access_key`:
+    the access key used to sign the request.
+
+-   `secret_key`:
+    the secret key used to sign the request.
+
+-   `query_auth`:
+    set to `True` if you want to add the signature to the query string.
+    The default is `False`, mean add the signature in the header.
+    Generally, only non-post request may need it. Optional
+
+-   `sign_payload`:
+    set to `True` if you want to sign the payload.The default is `False`.
+    Generally, only non-post request may need it. Optional
+
+
+-   `headers_not_to_sign`:
+    a list of header names, used to indicate which headers are not
+    needed  to be signed. Generally, only non-post request may need it. Optional.
+
+-   `request_date`:
+    timestamp or a iso base format date string, used to specify
+    a custom request date, instead of using current time as request date.
+    Optional.
+
+-   `signing_date`:
+    is a 8 digital date string like '20170131', used to specify a
+    custom signing date. Optional.
+
+-   `region`:
+    the region name of the service, the default is 'us-east-1'.
+
+-   `serive`:
+    the service name, the default is 's3'.
+
+-   `expires`:
+    specify the signature expire time in seconds.
+    It will overwrite the value of `default_expires`. Optional.
+
+#   Author
+
+Hubiyong (胡碧勇) <biyong.hu@baishancloud.com>
+
+#   Copyright and License
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Hubiyong (胡碧勇) <biyong.hu@baishancloud.com>

--- a/request/README.md
+++ b/request/README.md
@@ -17,7 +17,7 @@
 
 request
 
-Represents a http request including a normal request and an aws version 4 signature request 
+Represents a http request including a normal request and an aws version 4 signature request.
 
 #   Status
 
@@ -87,9 +87,10 @@ resp = conn.read_response()
 #   Description
 Request represents a http request including a normal request and an aws version 4
 signature request. You need to provide a python dict which represent your request
-(it typically contains `verb`,`uri`, `args`, `headers`, `body`, `fields`, `sign_args`),
-and your access key and secret key. Use request class to obtain a http request which
-can be sent directly.
+(it typically contains `verb`, `uri`, `args`, `headers`, `fields`, `sign_args`) and
+data to upload if you need. Use request class to obtain a http request which can be
+sent directly. The obtained request typically includes `verb`, `uri`, `args`, `headers`,
+`body`, `fields`, `sign_args`. `body` is a generator object or empty str.
 
 #   Classes
 
@@ -119,11 +120,6 @@ can be sent directly.
     -   `headers`:
         a python dict contains request headers. It must contain the `Host` header.
 
-    -   `body`:
-        a string contains the request payload. When provide a dict to construct a request,
-        body must be empty. Body is obtained by the fields in post request and is obtained
-        by the data in non post request. Body is str or generator type in our request.
-
     -   `fields`: a python dict which contains form fields. Only the post
         request fields is not empty, other situations fields is empty.
         It may contain the following attributes:
@@ -152,11 +148,11 @@ can be sent directly.
         -   `query_auth`:
             set to `True` if you want to add the signature to the query string.
             The default is `False`, mean add the signature in the header.
-            Generally, only non-post request may need it. Optional
+            Generally, only non-post request may need it. Optional.
 
         -   `sign_payload`:
             set to `True` if you want to sign the payload.The default is `False`.
-            Generally, only non-post request may need it. Optional
+            Generally, only non-post request may need it. Optional.
 
         -   `headers_not_to_sign`:
             a list of header names, used to indicate which headers are not
@@ -174,7 +170,7 @@ can be sent directly.
         -   `region`:
             the region name of the service, the default is `us-east-1`.
 
-        -   `serive`:
+        -   `service`:
             the service name, the default is `s3`.
 
         -   `expires`:

--- a/request/README.md
+++ b/request/README.md
@@ -65,14 +65,16 @@ dict1 = {
             ],
         },
     },
-    # add add_auth args to sign_args
-    'sign_args': {'access_key': access_key,
-                  'secret_key': secret_key,
-                  'request_date': '20180917T120101Z'}
+    # arguments for add authorization
+    'sign_args': {
+        'access_key': access_key,
+        'secret_key': secret_key,
+        'request_date': '20180917T120101Z',
+    }
 }
 
 # content can be a file or str in post request
-request1 = Request(dict1, do_add_auth = True, content = "file or str")
+request1 = Request(dict1, content = "file or str")
 
 # send request
 conn = http.Client(host, port)

--- a/request/README.md
+++ b/request/README.md
@@ -65,7 +65,7 @@ dict1 = {
             ],
         },
     },
-    # arguments for add authorization
+    # arguments for adding aws version 4 signature
     'sign_args': {
         'access_key': access_key,
         'secret_key': secret_key,
@@ -87,7 +87,7 @@ resp = conn.read_response()
 Request represents a http request including a normal request and an aws version 4
 signature request. You need to provide a python dict which represent your request
 (it typically contains `verb`,`uri`, `args`, `headers`, `body`, `fields`, `sign_args`),
-and your access key and secret key. Use request class to obtain a http request whicn
+and your access key and secret key. Use request class to obtain a http request which
 can be sent directly.
 
 #   Classes
@@ -140,7 +140,7 @@ can be sent directly.
         [here](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html)
         This method will add some signature related fields to this dict.
 
-    -   `sign_args`: a python dict which contain the args to add authorization. It may
+    -   `sign_args`: a python dict which contains the args to add aws version 4 signature. It may
         contain the following attributes:
 
         -   `access_key`:

--- a/request/README.md
+++ b/request/README.md
@@ -30,7 +30,6 @@ This library is considered production ready.
 # coding: utf-8
 
 from pykit import http
-from pykit import fsutil
 from pykit.request import Request
 
 bucket_name = 'your bucket name'
@@ -48,7 +47,6 @@ secret_key = 'your secret key'
 dict1 = {
     'verb': 'POST',
     'uri': '/',
-    'args': {},
     'headers': {
         'Host': host,
     },
@@ -109,8 +107,8 @@ sent directly. The obtained request typically includes `verb`, `uri`, `args`, `h
         the request method, such as `GET`, `PUT`, `POST`. Required.
 
     -   `uri`:
-        the url encoded uri. In PUT/GET request, it can contain query string
-        only when you did not specify `args` in `request`. Required.
+        the url encoded uri, it can contain query string only when
+        you did not specify `args` in `request`. Required.
 
     -   `args`:
         a python dict contains the request parameters, it should not be

--- a/request/README.md
+++ b/request/README.md
@@ -5,7 +5,8 @@
 - [Name](#name)
 - [Status](#status)
 - [Synopsis](#synopsis)
-
+- [Description](#description)
+- [Classes](#classes)
   - [Request](#request)
 - [Methods](#methods)
   - [Request.aws_sign](#requestaws_sign)
@@ -18,7 +19,7 @@
 
 request
 
-represents a http request including a normal request and  an aws version 4 signature request 
+Represents a http request including a normal request and an aws version 4 signature request 
 
 #   Status
 
@@ -27,9 +28,18 @@ This library is considered production ready.
 #   Synopsis
 
 ```python
+#!/usr/bin/env python2
+# coding: utf-8
+
+from pykit import http
+from pykit import fsutil
+from pykit.request import Request
+
 bucket_name = 'your bucket name'
-key_name = 'your key'
-endpoint = 'the endpoint'
+key_name = 'key name to upload'
+# https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
+# Host: destinationBucket.s3.amazonaws.com
+endpoint = 'endpoint domain name'
 
 host = bucket_name + '.' + endpoint
 port = portnumber
@@ -67,13 +77,13 @@ request1.content = "send post request"
 request1.aws_sign(access_key, secret_key, request_date='20180917T120101Z')
 # send request
 conn = http.Client(host, port)
-conn.send_request(request1['uri'], method='POST', headers=request1['headers'])
+conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
 conn.send_body(request1['body'])
 resp = conn.read_response()
 ```
 
 #   Description
-Request represents a http request including a normal request and  an aws version 4 signature request
+Request represents a http request including a normal request and an aws version 4 signature request.
 You need to provide a python dict which represent your request(it typically contains 'verb',
 'uri', 'args', 'headers', 'body', 'fields', 'do_add_auth'), and your access key and secret key.
 This lib will create a http request and add signature to the request(do_add_auth is True) by call function aws_sign().
@@ -104,8 +114,7 @@ This lib will create a http request and add signature to the request(do_add_auth
         at the same time. Generally this attribute is null in post request.
 
     -   `headers`:
-        a python dict contains request headers. It must contains the
-        'Host' header.
+        a python dict contains request headers. It must contain the 'Host' header.
 
     -   `body`:
         a string contains the request payload. In non-post request, If you do not want to sign
@@ -113,7 +122,7 @@ This lib will create a http request and add signature to the request(do_add_auth
         you can omit this field. In POST request, when provide a dict, body
         is null, body is obtained by the fields,
 
-    -   'fields': a python dict which contains form fields. Only the post reqeust the
+    -   'fields': a python dict which contains form fields. Only the post request the
         fields is not {}, other situations the value is {}.It may contain the following attributes:
         
         -   `Policy`:
@@ -162,7 +171,7 @@ this function can be called.
 
 -   `headers_not_to_sign`:
     a list of header names, used to indicate which headers are not
-    needed  to be signed. Generally, only non-post request may need it. Optional.
+    needed to be signed. Generally, only non-post request may need it. Optional.
 
 -   `request_date`:
     timestamp or a iso base format date string, used to specify

--- a/request/README.md
+++ b/request/README.md
@@ -35,10 +35,10 @@ from pykit.request import Request
 
 bucket_name = 'your bucket name'
 key_name = 'key name to upload'
-# https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
-# Host: destinationBucket.s3.amazonaws.com
 endpoint = 'endpoint domain name'
 
+# https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
+# Host: destinationBucket.endpoint
 host = bucket_name + '.' + endpoint
 port = portnumber
 
@@ -65,16 +65,14 @@ dict1 = {
             ],
         },
     },
-    'do_add_auth': 1,
-    # add add_auth args to sign_args dict
-    'sign_args': {'access_key': access_key, 'secret_key': secret_key,
+    # add add_auth args to sign_args
+    'sign_args': {'access_key': access_key,
+                  'secret_key': secret_key,
                   'request_date': '20180917T120101Z'}
 }
 
-request1 = Request(dict1)
-
 # content can be a file or str in post request
-request1.content = "send post request"
+request1 = Request(dict1, do_add_auth = True, content = "file or str")
 
 # send request
 conn = http.Client(host, port)
@@ -139,9 +137,6 @@ be sent directly.
         It also support some other fields, more infomation at
         [here](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html)
         This method will add some signature related fields to this dict.
-
-    -   `do_add_auth`:
-        a bool to mark whether it is a request to sign.
 
     -   `sign_args`: a python dict which contain the args to add_auth. It may
         contain the following attributes:

--- a/request/README.md
+++ b/request/README.md
@@ -73,8 +73,8 @@ dict1 = {
     }
 }
 
-# content can be a file or str in post request
-request1 = Request(dict1, content = "file or str")
+# data can be a file or str to upload
+request1 = Request(dict1, data = "file or str")
 
 # send request
 conn = http.Client(host, port)
@@ -86,9 +86,9 @@ resp = conn.read_response()
 #   Description
 Request represents a http request including a normal request and an aws version 4
 signature request. You need to provide a python dict which represent your request
-(it typically contains `verb`,`uri`, `args`, `headers`, `body`, `fields`, `do_add_auth`),
-and your access key and secret key. Use request class to obtain a http request whicn can
-be sent directly.
+(it typically contains `verb`,`uri`, `args`, `headers`, `body`, `fields`, `sign_args`),
+and your access key and secret key. Use request class to obtain a http request whicn
+can be sent directly.
 
 #   Classes
 
@@ -140,7 +140,7 @@ be sent directly.
         [here](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html)
         This method will add some signature related fields to this dict.
 
-    -   `sign_args`: a python dict which contain the args to add_auth. It may
+    -   `sign_args`: a python dict which contain the args to add authorization. It may
         contain the following attributes:
 
         -   `access_key`:

--- a/request/__init__.py
+++ b/request/__init__.py
@@ -1,0 +1,16 @@
+from .request import(
+    Request,
+
+    InvalidRequestError,
+    InvalidArgumentError,
+    InvalidMethodCall,
+)
+
+__all__ = [
+    'Request',
+
+    'InvalidRequestError',
+    'InvalidArgumentError',
+    'InvalidMethodCall',
+
+]

--- a/request/__init__.py
+++ b/request/__init__.py
@@ -1,6 +1,7 @@
-from .request import(
+from .request import (
     Request,
 
+    RequestError,
     InvalidRequestError,
     InvalidArgumentError,
     InvalidMethodCall,
@@ -9,6 +10,7 @@ from .request import(
 __all__ = [
     'Request',
 
+    'RequestError'
     'InvalidRequestError',
     'InvalidArgumentError',
     'InvalidMethodCall',

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python2
 # coding: utf-8
 
-import httplib
 from pykit import http
 from pykit.request import Request
 
@@ -78,13 +77,8 @@ if __name__ == '__main__':
 
     request2 = Request(dict2, data=file_content)
 
-    conn = httplib.HTTPConnection(host, port)
-
-    res_body = ''
+    conn = http.Client(host, port)
+    conn.send_request(request2['uri'], method=request2['verb'], headers=request2['headers'])
     for body in request2['body']:
-        res_body = body
-
-    conn.request(request2['verb'], request2['uri'], res_body, request2['headers'])
-    resp = conn.getresponse()
-    print resp.status
-    print resp.getheaders()
+        conn.send_body(body)
+    print conn.read_response

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -2,15 +2,13 @@
 # coding: utf-8
 
 import httplib
-import sys
 from pykit import http
-from pykit import fsutil
 from pykit.request import Request
 
 if __name__ == '__main__':
-    bucket_name = 'hu-by'
-    key_name = 'hbykey'
-    endpoint = 's2.lsl.com'
+    bucket_name = 'your bucket name'
+    key_name = 'key name to upload'
+    endpoint = 's2 endpoint domain name'
 
     # https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
     # Host must be in the format of destinationBucket.endpoint
@@ -18,8 +16,8 @@ if __name__ == '__main__':
     host = bucket_name + '.' + endpoint
     port = 80
 
-    access_key = 'u36vatc28bqy41oershl'
-    secret_key = 'oTOZx9ONjXwOhqv6OMo1swa6eJECmf2d9xlqErdC'
+    access_key = 'your access key'
+    secret_key = 'your secret key'
     # send a post request
     dict1 = {
         'verb': 'POST',
@@ -45,12 +43,11 @@ if __name__ == '__main__':
     }
     request1 = Request(dict1)
 
-    # upload a file
-    fsutil.write_file('./hubiyong.txt', 'test upload a file')
+    # upload a file, here content is a file object
     request1.content = open('./hubiyong.txt')
     request1.aws_sign(access_key, secret_key, request_date='20180918T120101Z')
     conn = http.Client(host, port)
-    conn.send_request(request1['uri'], method='POST', headers=request1['headers'])
+    conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
     conn.send_body(request1['body'])
     print conn.read_response()
 

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -64,7 +64,6 @@ if __name__ == '__main__':
         },
         'headers': {
                 'Host': host,
-                'Content-Length': len(file_content),
         },
         'sign_args': {
             'access_key': access_key,

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -21,7 +21,6 @@ if __name__ == '__main__':
     dict1 = {
         'verb': 'POST',
         'uri': '/',
-        'args': {},
         'headers': {
             'Host': host,
         },
@@ -54,20 +53,19 @@ if __name__ == '__main__':
     print conn.read_response()
 
     # send a put request
-    file_content = "hby is testing sending put request"
+    file_content = "test sending put request"
     dict2 = {
         'verb': 'PUT',
-        'uri': '/hu-by/test-key2',
+        'uri': '/bucket_name/key_name',
         'args': {
                 'foo2': 'bar2',
                 'foo1': True,
                 'foo3': ['bar3', True],
-            },
+        },
         'headers': {
                 'Host': host,
                 'Content-Length': len(file_content),
-            },
-        'fields': {},
+        },
         'sign_args': {
             'access_key': access_key,
             'secret_key': secret_key,

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -26,7 +26,6 @@ if __name__ == '__main__':
         'headers': {
             'Host': host,
         },
-        'body': '',
         'fields': {
             'key': key_name,
             'Policy': {
@@ -67,7 +66,6 @@ if __name__ == '__main__':
                 'Host': host,
                 'Content-Length': len(file_content),
             },
-        'body': '',
         'fields': {},
         'sign_args': {
             'access_key': access_key,

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+import httplib
+import sys
+from pykit import http
+from pykit import fsutil
+from pykit.request import Request
+
+if __name__ == '__main__':
+    bucket_name = 'hu-by'
+    key_name = 'hbykey'
+    endpoint = 's2.lsl.com'
+
+    # https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
+    # Host must be in the format of destinationBucket.endpoint
+    # you should add it in /etc/hosts
+    host = bucket_name + '.' + endpoint
+    port = 80
+
+    access_key = 'u36vatc28bqy41oershl'
+    secret_key = 'oTOZx9ONjXwOhqv6OMo1swa6eJECmf2d9xlqErdC'
+    # send a post request
+    dict1 = {
+        'verb': 'POST',
+        'uri': '/',
+        'args': {},
+        'headers': {
+            'Host': host,
+        },
+        'body': '',
+        'fields': {
+            'key': key_name,
+            'Policy': {
+                'expiration': '2018-09-30T12:00:00.000Z',
+                'conditions': [
+                    ['starts-with', '$key', ''],
+                    {
+                        'bucket': bucket_name,
+                    },
+                ],
+            },
+        },
+        'do_add_auth': True
+    }
+    request1 = Request(dict1)
+
+    # upload a file
+    fsutil.write_file('./hubiyong.txt', 'test upload a file')
+    request1.content = open('./hubiyong.txt')
+    request1.aws_sign(access_key, secret_key, request_date='20180918T120101Z')
+    conn = http.Client(host, port)
+    conn.send_request(request1['uri'], method='POST', headers=request1['headers'])
+    conn.send_body(request1['body'])
+    print conn.read_response()
+
+    # send a put request
+    file_content = "hby is testing sending put request"
+    dict2 = {
+        'verb': 'PUT',
+        'uri': '/hu-by/test-key2',
+        'args': {
+                'foo2': 'bar2',
+                'foo1': True,
+                'foo3': ['bar3', True],
+            },
+        'headers': {
+                'Host': host,
+                'Content-Length': len(file_content),
+            },
+        'body': file_content,
+        'fields': {},
+        'do_add_auth': True
+    }
+
+    request2 = Request(dict2)
+    request2.aws_sign(access_key, secret_key, sign_payload=True)
+    conn = httplib.HTTPConnection(host, port)
+    conn.request(request2['verb'], request2['uri'], request2['body'], request2['headers'])
+    resp = conn.getresponse()
+    print resp.status
+    print resp.getheaders()

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -49,7 +49,9 @@ if __name__ == '__main__':
 
     conn = http.Client(host, port)
     conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
-    conn.send_body(request1['body'])
+    # request1['body'] is a generator object
+    for body in request1['body']:
+        conn.send_body(body)
     print conn.read_response()
 
     # send a put request
@@ -77,7 +79,12 @@ if __name__ == '__main__':
     request2 = Request(dict2, data=file_content)
 
     conn = httplib.HTTPConnection(host, port)
-    conn.request(request2['verb'], request2['uri'], request2['body'], request2['headers'])
+
+    res_body = ''
+    for body in request2['body']:
+        res_body = body
+
+    conn.request(request2['verb'], request2['uri'], res_body, request2['headers'])
     resp = conn.getresponse()
     print resp.status
     print resp.getheaders()

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -39,14 +39,12 @@ if __name__ == '__main__':
                 ],
             },
         },
-        'do_add_auth': True,
-        'sign_args': {'access_key': access_key, 'secret_key': secret_key,
+        'sign_args': {'access_key': access_key,
+                      'secret_key': secret_key,
                       'request_date': '20180918T120101Z'}
     }
-    request1 = Request(dict1)
 
-    # upload a file, here content is a file object
-    request1.content = open('./hubiyong.txt')
+    request1 = Request(dict1, do_add_auth=True, content=open('./xxx.txt'))
 
     conn = http.Client(host, port)
     conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
@@ -69,12 +67,11 @@ if __name__ == '__main__':
             },
         'body': file_content,
         'fields': {},
-        'do_add_auth': True,
         'sign_args': {'access_key': access_key, 'secret_key': secret_key,
                       'sign_payload': True}
     }
 
-    request2 = Request(dict2)
+    request2 = Request(dict2, do_add_auth=True)
 
     conn = httplib.HTTPConnection(host, port)
     conn.request(request2['verb'], request2['uri'], request2['body'], request2['headers'])

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -39,13 +39,15 @@ if __name__ == '__main__':
                 ],
             },
         },
-        'do_add_auth': True
+        'do_add_auth': True,
+        'sign_args': {'access_key': access_key, 'secret_key': secret_key,
+                      'request_date': '20180918T120101Z'}
     }
     request1 = Request(dict1)
 
     # upload a file, here content is a file object
     request1.content = open('./hubiyong.txt')
-    request1.aws_sign(access_key, secret_key, request_date='20180918T120101Z')
+
     conn = http.Client(host, port)
     conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
     conn.send_body(request1['body'])
@@ -67,11 +69,13 @@ if __name__ == '__main__':
             },
         'body': file_content,
         'fields': {},
-        'do_add_auth': True
+        'do_add_auth': True,
+        'sign_args': {'access_key': access_key, 'secret_key': secret_key,
+                      'sign_payload': True}
     }
 
     request2 = Request(dict2)
-    request2.aws_sign(access_key, secret_key, sign_payload=True)
+
     conn = httplib.HTTPConnection(host, port)
     conn.request(request2['verb'], request2['uri'], request2['body'], request2['headers'])
     resp = conn.getresponse()

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
         }
     }
 
-    request1 = Request(dict1, content=open('./xxx.txt'))
+    request1 = Request(dict1, data=open('./xxx.txt'))
 
     conn = http.Client(host, port)
     conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
@@ -67,7 +67,7 @@ if __name__ == '__main__':
                 'Host': host,
                 'Content-Length': len(file_content),
             },
-        'body': file_content,
+        'body': '',
         'fields': {},
         'sign_args': {
             'access_key': access_key,
@@ -76,7 +76,7 @@ if __name__ == '__main__':
         }
     }
 
-    request2 = Request(dict2)
+    request2 = Request(dict2, data=file_content)
 
     conn = httplib.HTTPConnection(host, port)
     conn.request(request2['verb'], request2['uri'], request2['body'], request2['headers'])

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -39,12 +39,14 @@ if __name__ == '__main__':
                 ],
             },
         },
-        'sign_args': {'access_key': access_key,
-                      'secret_key': secret_key,
-                      'request_date': '20180918T120101Z'}
+        'sign_args': {
+            'access_key': access_key,
+            'secret_key': secret_key,
+            'request_date': '20180918T120101Z',
+        }
     }
 
-    request1 = Request(dict1, do_add_auth=True, content=open('./xxx.txt'))
+    request1 = Request(dict1, content=open('./xxx.txt'))
 
     conn = http.Client(host, port)
     conn.send_request(request1['uri'], method=request1['verb'], headers=request1['headers'])
@@ -67,11 +69,14 @@ if __name__ == '__main__':
             },
         'body': file_content,
         'fields': {},
-        'sign_args': {'access_key': access_key, 'secret_key': secret_key,
-                      'sign_payload': True}
+        'sign_args': {
+            'access_key': access_key,
+            'secret_key': secret_key,
+            'sign_payload': True,
+        }
     }
 
-    request2 = Request(dict2, do_add_auth=True)
+    request2 = Request(dict2)
 
     conn = httplib.HTTPConnection(host, port)
     conn.request(request2['verb'], request2['uri'], request2['body'], request2['headers'])

--- a/request/request.py
+++ b/request/request.py
@@ -1,94 +1,78 @@
 #!/usr/bin/env python2
 # coding: utf-8
 
-import sys
 import os
 from pykit import awssign
 from pykit import httpmultipart
 from pykit.dictutil import FixedKeysDict
 
 
-class InvalidRequestError(Exception):
+class RequestError(Exception):
     pass
 
 
-class InvalidArgumentError(Exception):
+class InvalidRequestError(RequestError):
     pass
 
 
-class InvalidMethodCall(Exception):
+class InvalidArgumentError(RequestError):
     pass
 
 
-def _str(arg=''):
+class InvalidMethodCall(RequestError):
+    pass
+
+
+def _basestring(arg=''):
+    if isinstance(arg, basestring) is False:
+        raise InvalidArgumentError('The argument must be str or unicode type')
     return arg
 
 
 class Request(FixedKeysDict):
-    keys_default = dict((('verb', _str),
-                         ('uri', _str),
+    keys_default = dict((('verb', _basestring),
+                         ('uri', _basestring),
                          ('args', dict),
                          ('headers', dict),
-                         ('body', _str),
+                         ('body', _basestring),
                          ('fields', dict),
                          ('do_add_auth', bool),))
 
     def __init__(self, *args, **argkv):
 
-        # content represents str or a file to  upload in POST request
+        # content represents str or a file to upload in POST request
         self.content = None
         super(FixedKeysDict, self).__init__(*args, **argkv)
 
-        if self['verb'] == 'POST' and self['fields'] == {}:
-            raise InvalidRequestError('POST request needs fields attribute ')
-
-        if self['verb'] != 'POST' and self['fields'] != {}:
-            raise InvalidRequestError('non POST request must not contain fields attribute')
-
-        if self['verb'] == 'POST' and self['body'] != '':
-            raise InvalidRequestError('body is made by fields in post request')
-
         if self['verb'] == 'POST':
-            if self['do_add_auth'] == False:
-                self['body'], self['headers'] = self._init_body_headers()
+            if self['fields'] == {} or self['body'] != '':
+                raise InvalidRequestError('In post request, dict needs fields attribute and body is made by fields')
+            if self['do_add_auth'] is False:
+                self['body'], self['headers'] = self._make_post_body_headers()
+        elif self['fields'] != {}:
+                raise InvalidRequestError('non POST request must not contain fields attribute')
 
-    def aws_sign(self, access_key, secret_key, query_auth=False, sign_payload=False, headers_not_to_sign=[],
+    def aws_sign(self, access_key, secret_key, query_auth=False, sign_payload=False, headers_not_to_sign=None,
                  request_date=None, signing_date=None, region='us-east-1', service='s3', expires=60):
 
-        if self['do_add_auth'] == False:
+        if headers_not_to_sign is None:
+            headers_not_to_sign = []
+
+        if self['do_add_auth'] is False:
             raise InvalidMethodCall('only add_auth request can call this method')
 
         signer = awssign.Signer(access_key, secret_key, region=region, service=service, default_expires=expires)
 
         if self['verb'] == 'POST':
             res = signer.add_post_auth(self['fields'], request_date=request_date, signing_date=signing_date)
-            self['body'], self['headers'] = self._make_body_headers()
+            self['body'], self['headers'] = self._make_post_body_headers()
             return res
         else:
             res = signer.add_auth(self, query_auth=query_auth, sign_payload=sign_payload,
                                   headers_not_to_sign=headers_not_to_sign, request_date=request_date, signing_date=signing_date)
             return res
 
-    def _init_body_headers(self):
-
-        fields = self['fields']
-        headers = self['headers']
-        multipart_cli = httpmultipart.Multipart()
-        multipart_fields = []
-
-        for k, v in fields.iteritems():
-            multipart_fields.append({'name': k, 'value': v})
-
-        body_reader =  multipart_cli.make_body_reader(multipart_fields)
-        data = []
-        for body in body_reader:
-            data.append(body)
-        res_body = ''.join(data)
-        headers = multipart_cli.make_headers(multipart_fields, headers)
-
-        return res_body, headers
-
-    def _make_body_headers(self):
+    def _make_post_body_headers(self):
 
         fields = self['fields']
         headers = self['headers']
@@ -99,29 +83,30 @@ class Request(FixedKeysDict):
         for k, v in fields.iteritems():
             multipart_fields.append({'name': k, 'value': v})
 
-        if content is None:
-            multipart_fields.append({
-                'name': 'file',
-                'value': '',
-                })
-        elif isinstance(content, str):
-            multipart_fields.append({
-                'name': 'file',
-                'value': content,
-                })
-        elif isinstance(content, file):
-            multipart_fields.append({
-                'name': 'file',
-                'value': [content, os.fstat(content.fileno()).st_size, os.path.basename(content.name)],
-                })
-        else:
-            raise InvalidArgumentError('content to upload must be a file or str')
+        if self['do_add_auth'] is True:
+            if content is None:
+                multipart_fields.append({
+                    'name': 'file',
+                    'value': '',
+                    })
+            elif isinstance(content, str):
+                multipart_fields.append({
+                    'name': 'file',
+                    'value': content,
+                    })
+            elif isinstance(content, file):
+                multipart_fields.append({
+                    'name': 'file',
+                    'value': [content, os.fstat(content.fileno()).st_size, os.path.basename(content.name)],
+                    })
+            else:
+                raise InvalidArgumentError('content to upload must be a file or str')
 
-        headers = multipart_cli.make_headers(multipart_fields, headers)
-        body_reader =  multipart_cli.make_body_reader(multipart_fields)
+        body_reader = multipart_cli.make_body_reader(multipart_fields)
         data = []
         for body in body_reader:
             data.append(body)
         res_body = ''.join(data)
+        headers = multipart_cli.make_headers(multipart_fields, headers)
 
         return res_body, headers

--- a/request/request.py
+++ b/request/request.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+import sys
+import os
+from pykit import awssign
+from pykit import httpmultipart
+from pykit.dictutil import FixedKeysDict
+
+
+class InvalidRequestError(Exception):
+    pass
+
+
+class InvalidArgumentError(Exception):
+    pass
+
+
+class InvalidMethodCall(Exception):
+    pass
+
+
+def _str(arg=''):
+    return arg
+
+
+class Request(FixedKeysDict):
+    keys_default = dict((('verb', _str),
+                         ('uri', _str),
+                         ('args', dict),
+                         ('headers', dict),
+                         ('body', _str),
+                         ('fields', dict),
+                         ('do_add_auth', bool),))
+
+    def __init__(self, *args, **argkv):
+
+        # content represents str or a file to  upload in POST request
+        self.content = None
+        super(FixedKeysDict, self).__init__(*args, **argkv)
+
+        if self['verb'] == 'POST' and self['fields'] == {}:
+            raise InvalidRequestError('POST request needs fields attribute ')
+
+        if self['verb'] != 'POST' and self['fields'] != {}:
+            raise InvalidRequestError('non POST request must not contain fields attribute')
+
+        if self['verb'] == 'POST' and self['body'] != '':
+            raise InvalidRequestError('body is made by fields in post request')
+
+        if self['verb'] == 'POST':
+            if self['do_add_auth'] == False:
+                self['body'], self['headers'] = self._init_body_headers()
+
+    def aws_sign(self, access_key, secret_key, query_auth=False, sign_payload=False, headers_not_to_sign=[],
+                 request_date=None, signing_date=None, region='us-east-1', service='s3', expires=60):
+
+        if self['do_add_auth'] == False:
+            raise InvalidMethodCall('only add_auth request can call this method')
+
+        signer = awssign.Signer(access_key, secret_key, region=region, service=service, default_expires=expires)
+
+        if self['verb'] == 'POST':
+            res = signer.add_post_auth(self['fields'], request_date=request_date, signing_date=signing_date)
+            self['body'], self['headers'] = self._make_body_headers()
+            return res
+        else:
+            res = signer.add_auth(self, query_auth=query_auth, sign_payload=sign_payload,
+                                  headers_not_to_sign=headers_not_to_sign, request_date=request_date, signing_date=signing_date)
+            return res
+
+    def _init_body_headers(self):
+
+        fields = self['fields']
+        headers = self['headers']
+        multipart_cli = httpmultipart.Multipart()
+        multipart_fields = []
+
+        for k, v in fields.iteritems():
+            multipart_fields.append({'name': k, 'value': v})
+
+        body_reader =  multipart_cli.make_body_reader(multipart_fields)
+        data = []
+        for body in body_reader:
+            data.append(body)
+        res_body = ''.join(data)
+        headers = multipart_cli.make_headers(multipart_fields, headers)
+
+        return res_body, headers
+
+    def _make_body_headers(self):
+
+        fields = self['fields']
+        headers = self['headers']
+        multipart_cli = httpmultipart.Multipart()
+        multipart_fields = []
+        content = self.content
+
+        for k, v in fields.iteritems():
+            multipart_fields.append({'name': k, 'value': v})
+
+        if content is None:
+            multipart_fields.append({
+                'name': 'file',
+                'value': '',
+                })
+        elif isinstance(content, str):
+            multipart_fields.append({
+                'name': 'file',
+                'value': content,
+                })
+        elif isinstance(content, file):
+            multipart_fields.append({
+                'name': 'file',
+                'value': [content, os.fstat(content.fileno()).st_size, os.path.basename(content.name)],
+                })
+        else:
+            raise InvalidArgumentError('content to upload must be a file or str')
+
+        headers = multipart_cli.make_headers(multipart_fields, headers)
+        body_reader =  multipart_cli.make_body_reader(multipart_fields)
+        data = []
+        for body in body_reader:
+            data.append(body)
+        res_body = ''.join(data)
+
+        return res_body, headers

--- a/request/request.py
+++ b/request/request.py
@@ -23,13 +23,16 @@ class InvalidMethodCall(RequestError):
     pass
 
 
+# the arg  must be str or unicode type
 def _basestring(arg=''):
-    if isinstance(arg, basestring) is False:
-        raise InvalidArgumentError('The argument must be str or unicode type')
+    if not isinstance(arg, basestring):
+        raise InvalidArgumentError('type of arg {x} is not str or unicode'.format(x=type(arg)))
+
     return arg
 
 
 class Request(FixedKeysDict):
+
     keys_default = dict((('verb', _basestring),
                          ('uri', _basestring),
                          ('args', dict),
@@ -39,18 +42,21 @@ class Request(FixedKeysDict):
                          ('do_add_auth', bool),))
 
     def __init__(self, *args, **argkv):
-
-        # content represents str or a file to upload in POST request
+        # content represents str or a file to upload in post request
         self.content = None
         super(FixedKeysDict, self).__init__(*args, **argkv)
 
         if self['verb'] == 'POST':
-            if self['fields'] == {} or self['body'] != '':
-                raise InvalidRequestError('In post request, dict needs fields attribute and body is made by fields')
-            if self['do_add_auth'] is False:
+            if len(self['fields']) == 0:
+                raise InvalidRequestError('fields is null when init post request')
+            if self['body'] != '':
+                raise InvalidRequestError('body is not null when init post request')
+            if not self['do_add_auth']:
                 self['body'], self['headers'] = self._make_post_body_headers()
-        elif self['fields'] != {}:
-                raise InvalidRequestError('non POST request must not contain fields attribute')
+
+        else:
+            if self['fields']:
+                raise InvalidRequestError('non-post request contains fields attribute: {fields}'.format(fields=self['fields']))
 
     def aws_sign(self, access_key, secret_key, query_auth=False, sign_payload=False, headers_not_to_sign=None,
                  request_date=None, signing_date=None, region='us-east-1', service='s3', expires=60):
@@ -58,19 +64,20 @@ class Request(FixedKeysDict):
         if headers_not_to_sign is None:
             headers_not_to_sign = []
 
-        if self['do_add_auth'] is False:
-            raise InvalidMethodCall('only add_auth request can call this method')
+        if not self['do_add_auth']:
+            raise InvalidMethodCall('non add_auth request calls aws_sign() method')
 
         signer = awssign.Signer(access_key, secret_key, region=region, service=service, default_expires=expires)
 
         if self['verb'] == 'POST':
-            res = signer.add_post_auth(self['fields'], request_date=request_date, signing_date=signing_date)
+            ctx = signer.add_post_auth(self['fields'], request_date=request_date, signing_date=signing_date)
             self['body'], self['headers'] = self._make_post_body_headers()
-            return res
+
         else:
-            res = signer.add_auth(self, query_auth=query_auth, sign_payload=sign_payload,
+            ctx = signer.add_auth(self, query_auth=query_auth, sign_payload=sign_payload,
                                   headers_not_to_sign=headers_not_to_sign, request_date=request_date, signing_date=signing_date)
-            return res
+
+        return ctx
 
     def _make_post_body_headers(self):
 
@@ -83,24 +90,27 @@ class Request(FixedKeysDict):
         for k, v in fields.iteritems():
             multipart_fields.append({'name': k, 'value': v})
 
-        if self['do_add_auth'] is True:
+        if self['do_add_auth']:
             if content is None:
                 multipart_fields.append({
                     'name': 'file',
                     'value': '',
                     })
+
             elif isinstance(content, str):
                 multipart_fields.append({
                     'name': 'file',
                     'value': content,
                     })
+
             elif isinstance(content, file):
                 multipart_fields.append({
                     'name': 'file',
                     'value': [content, os.fstat(content.fileno()).st_size, os.path.basename(content.name)],
                     })
+
             else:
-                raise InvalidArgumentError('content to upload must be a file or str')
+                raise InvalidArgumentError('type of content {x} is not str or file'.format(x=type(content)))
 
         body_reader = multipart_cli.make_body_reader(multipart_fields)
         data = []

--- a/request/request.py
+++ b/request/request.py
@@ -26,7 +26,8 @@ class InvalidMethodCall(RequestError):
 # the arg  must be str or unicode type
 def _basestring(arg=''):
     if not isinstance(arg, basestring):
-        raise InvalidArgumentError('type of arg {x} should be str or unicode'.format(x=type(arg)))
+        raise InvalidArgumentError(
+            'type of arg is: {x}, should be str or unicode'.format(x=type(arg)))
 
     return arg
 
@@ -56,8 +57,7 @@ class Request(FixedKeysDict):
 
         else:
             if self['fields']:
-                raise InvalidRequestError(
-                    'non-post request can not contain fields: {fields}'.format(fields=self['fields']))
+                raise InvalidRequestError('fields should be empty in non post request')
 
     def aws_sign(self, access_key, secret_key, query_auth=False, sign_payload=False, headers_not_to_sign=None,
                  request_date=None, signing_date=None, region='us-east-1', service='s3', expires=60):
@@ -111,7 +111,8 @@ class Request(FixedKeysDict):
                     })
 
             else:
-                raise InvalidArgumentError('type of content {x} is not str or file'.format(x=type(content)))
+                raise InvalidArgumentError(
+                    'type of content is: {x}, should be str or file'.format(x=type(content)))
 
         body_reader = multipart_cli.make_body_reader(multipart_fields)
         data = []

--- a/request/request.py
+++ b/request/request.py
@@ -26,7 +26,7 @@ class InvalidMethodCall(RequestError):
 # the arg  must be str or unicode type
 def _basestring(arg=''):
     if not isinstance(arg, basestring):
-        raise InvalidArgumentError('type of arg {x} is not str or unicode'.format(x=type(arg)))
+        raise InvalidArgumentError('type of arg {x} should be str or unicode'.format(x=type(arg)))
 
     return arg
 
@@ -48,15 +48,16 @@ class Request(FixedKeysDict):
 
         if self['verb'] == 'POST':
             if len(self['fields']) == 0:
-                raise InvalidRequestError('fields is null when init post request')
+                raise InvalidRequestError('fields can not be empty in post request')
             if self['body'] != '':
-                raise InvalidRequestError('body is not null when init post request')
+                raise InvalidRequestError('body in init dict should be empty in post request')
             if not self['do_add_auth']:
                 self['body'], self['headers'] = self._make_post_body_headers()
 
         else:
             if self['fields']:
-                raise InvalidRequestError('non-post request contains fields attribute: {fields}'.format(fields=self['fields']))
+                raise InvalidRequestError(
+                    'non-post request can not contain fields: {fields}'.format(fields=self['fields']))
 
     def aws_sign(self, access_key, secret_key, query_auth=False, sign_payload=False, headers_not_to_sign=None,
                  request_date=None, signing_date=None, region='us-east-1', service='s3', expires=60):
@@ -65,7 +66,7 @@ class Request(FixedKeysDict):
             headers_not_to_sign = []
 
         if not self['do_add_auth']:
-            raise InvalidMethodCall('non add_auth request calls aws_sign() method')
+            raise InvalidMethodCall('non add_auth request can not call aws_sign() method')
 
         signer = awssign.Signer(access_key, secret_key, region=region, service=service, default_expires=expires)
 
@@ -74,8 +75,8 @@ class Request(FixedKeysDict):
             self['body'], self['headers'] = self._make_post_body_headers()
 
         else:
-            ctx = signer.add_auth(self, query_auth=query_auth, sign_payload=sign_payload,
-                                  headers_not_to_sign=headers_not_to_sign, request_date=request_date, signing_date=signing_date)
+            ctx = signer.add_auth(self, query_auth=query_auth, headers_not_to_sign=headers_not_to_sign,
+                                  sign_payload=sign_payload, request_date=request_date, signing_date=signing_date)
 
         return ctx
 

--- a/request/request.py
+++ b/request/request.py
@@ -27,9 +27,106 @@ class InvalidMethodCall(RequestError):
 def _basestring(arg=''):
     if not isinstance(arg, basestring):
         raise InvalidArgumentError(
-            'type of arg is: {x}, should be str or unicode'.format(x=type(arg)))
+            'type of arg should be str or unicode, get {t}'.format(t=type(arg)))
 
     return arg
+
+
+def _get_sign_args(auth_args=None):
+
+    if auth_args is None:
+        return {}
+
+    if not isinstance(auth_args, dict):
+        raise InvalidArgumentError(
+            'type of auth_args should be dict, got {t}'.format(t=type(auth_args)))
+
+    if 'access_key' not in auth_args:
+        raise InvalidArgumentError('add_auth request must contain access key')
+
+    if 'secret_key' not in auth_args:
+        raise InvalidArgumentError('add_auth request must contain secret key')
+
+    # add absent key and set default value
+    if 'query_auth' not in auth_args:
+        auth_args['query_auth'] = False
+
+    if 'sign_payload' not in auth_args:
+        auth_args['sign_payload'] = False
+
+    if 'headers_not_to_sign' not in auth_args:
+        auth_args['headers_not_to_sign'] = []
+
+    if 'request_date' not in auth_args:
+        auth_args['request_date'] = None
+
+    if 'signing_date' not in auth_args:
+        auth_args['signing_date'] = None
+
+    if 'region' not in auth_args:
+        auth_args['region'] = 'us-east-1'
+
+    if 'service' not in auth_args:
+        auth_args['service'] = 's3'
+
+    if 'expires' not in auth_args:
+        auth_args['expires'] = 60
+
+    return {'region': auth_args['region'],
+            'service': auth_args['service'],
+            'expires': auth_args['expires'],
+            'access_key': auth_args['access_key'],
+            'secret_key': auth_args['secret_key'],
+            'query_auth': auth_args['query_auth'],
+            'sign_payload': auth_args['sign_payload'],
+            'request_date': auth_args['request_date'],
+            'signing_date': auth_args['signing_date'],
+            'headers_not_to_sign': auth_args['headers_not_to_sign']
+            }
+
+
+def _make_post_body_headers(fields, headers, do_add_auth, content):
+
+    multipart_cli = httpmultipart.Multipart()
+    multipart_fields = []
+
+    for k, v in fields.iteritems():
+        multipart_fields.append({'name': k, 'value': v})
+
+    if do_add_auth:
+        if content is None:
+            multipart_fields.append({
+                'name': 'file',
+                'value': '',
+                })
+
+        elif isinstance(content, str):
+            multipart_fields.append({
+                'name': 'file',
+                'value': content,
+                })
+
+        elif isinstance(content, file):
+            multipart_fields.append({
+                'name': 'file',
+                'value': [content, os.fstat(content.fileno()).st_size,
+                          os.path.basename(content.name)],
+                })
+
+        else:
+            raise InvalidArgumentError(
+                'type of content should be str or unicode, get {t}'.format(t=type(content)))
+
+    body_reader = multipart_cli.make_body_reader(multipart_fields)
+    data = []
+
+    for body in body_reader:
+        data.append(body)
+
+    res_body = ''.join(data)
+    headers = multipart_cli.make_headers(multipart_fields, headers)
+
+    return res_body, headers
 
 
 class Request(FixedKeysDict):
@@ -40,85 +137,65 @@ class Request(FixedKeysDict):
                          ('headers', dict),
                          ('body', _basestring),
                          ('fields', dict),
-                         ('do_add_auth', bool),))
+                         ('do_add_auth', bool),
+                         ('sign_args', _get_sign_args),))
 
     def __init__(self, *args, **argkv):
         # content represents str or a file to upload in post request
         self.content = None
-        super(FixedKeysDict, self).__init__(*args, **argkv)
+        super(Request, self).__init__(*args, **argkv)
+
+        region = self['sign_args']['region']
+        service = self['sign_args']['service']
+        expires = self['sign_args']['expires']
+        access_key = self['sign_args']['access_key']
+        secret_key = self['sign_args']['secret_key']
+
+        query_auth = self['sign_args']['query_auth']
+        sign_payload = self['sign_args']['sign_payload']
+        request_date = self['sign_args']['request_date']
+        signing_date = self['sign_args']['signing_date']
+        headers_not_to_sign = self['sign_args']['headers_not_to_sign']
+
+        signer = awssign.Signer(access_key, secret_key, region=region,
+                                service=service, default_expires=expires)
+
+        if self['do_add_auth']:
+            if len(self['sign_args']) == 0:
+                raise InvalidRequestError(
+                    'sign_args can not be empty in add_auth request')
+
+        else:
+            if self['sign_args']:
+                raise InvalidRequestError(
+                    'sign_args must be empty in non add_auth request')
 
         if self['verb'] == 'POST':
             if len(self['fields']) == 0:
                 raise InvalidRequestError('fields can not be empty in post request')
+
             if self['body'] != '':
-                raise InvalidRequestError('body in init dict should be empty in post request')
-            if not self['do_add_auth']:
-                self['body'], self['headers'] = self._make_post_body_headers()
+                raise InvalidRequestError(
+                    'body in init dict should be empty in post request')
+
+            if self['do_add_auth']:
+                signer.add_post_auth(self['fields'], request_date=request_date,
+                                     signing_date=signing_date)
+
+                self['body'], self['headers'] = _make_post_body_headers(
+                    self['fields'], self['headers'], self['do_add_auth'], self.content)
+
+            else:
+                self['body'], self['headers'] = _make_post_body_headers(
+                    self['fields'], self['headers'], self['do_add_auth'], self.content)
 
         else:
             if self['fields']:
                 raise InvalidRequestError('fields should be empty in non post request')
 
-    def aws_sign(self, access_key, secret_key, query_auth=False, sign_payload=False, headers_not_to_sign=None,
-                 request_date=None, signing_date=None, region='us-east-1', service='s3', expires=60):
-
-        if headers_not_to_sign is None:
-            headers_not_to_sign = []
-
-        if not self['do_add_auth']:
-            raise InvalidMethodCall('non add_auth request can not call aws_sign() method')
-
-        signer = awssign.Signer(access_key, secret_key, region=region, service=service, default_expires=expires)
-
-        if self['verb'] == 'POST':
-            ctx = signer.add_post_auth(self['fields'], request_date=request_date, signing_date=signing_date)
-            self['body'], self['headers'] = self._make_post_body_headers()
-
-        else:
-            ctx = signer.add_auth(self, query_auth=query_auth, headers_not_to_sign=headers_not_to_sign,
-                                  sign_payload=sign_payload, request_date=request_date, signing_date=signing_date)
-
-        return ctx
-
-    def _make_post_body_headers(self):
-
-        fields = self['fields']
-        headers = self['headers']
-        multipart_cli = httpmultipart.Multipart()
-        multipart_fields = []
-        content = self.content
-
-        for k, v in fields.iteritems():
-            multipart_fields.append({'name': k, 'value': v})
-
-        if self['do_add_auth']:
-            if content is None:
-                multipart_fields.append({
-                    'name': 'file',
-                    'value': '',
-                    })
-
-            elif isinstance(content, str):
-                multipart_fields.append({
-                    'name': 'file',
-                    'value': content,
-                    })
-
-            elif isinstance(content, file):
-                multipart_fields.append({
-                    'name': 'file',
-                    'value': [content, os.fstat(content.fileno()).st_size, os.path.basename(content.name)],
-                    })
-
-            else:
-                raise InvalidArgumentError(
-                    'type of content is: {x}, should be str or file'.format(x=type(content)))
-
-        body_reader = multipart_cli.make_body_reader(multipart_fields)
-        data = []
-        for body in body_reader:
-            data.append(body)
-        res_body = ''.join(data)
-        headers = multipart_cli.make_headers(multipart_fields, headers)
-
-        return res_body, headers
+            if self['do_add_auth']:
+                signer.add_auth(self, query_auth=query_auth,
+                                sign_payload=sign_payload,
+                                request_date=request_date,
+                                signing_date=signing_date,
+                                headers_not_to_sign=headers_not_to_sign)

--- a/request/request.py
+++ b/request/request.py
@@ -107,11 +107,11 @@ def _make_str_reader(data):
     yield data
 
 
-def _make_file_reader(data):
+def _make_file_reader(file_obj):
     block_size = 1024 * 1024
 
     while True:
-        buf = data.read(block_size)
+        buf = file_obj.read(block_size)
         if buf == '':
             break
         yield buf

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -68,3 +68,34 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(('eyJleHBpcmF0aW9uIjogIjIwMTgtMDEtMDFUMTI6MDA6MDAuMDAwWiIsICJjb25kaXRpb24i'
                           'OiBbWyJzdGFydHMtd2l0aCIsICIka2V5IiwgIiJdLCB7ImJ1Y2tldCI6ICJ0ZXN0LWJ1Y2tldCJ9XX0='),
                          request2['fields']['Policy'])
+
+    def test_unicode(self):
+        unicode_str = '测试'.decode('utf-8')
+        dict3 = {
+            'verb': u'GET',
+            'uri': '/' + unicode_str,
+            'args': {
+                unicode_str: unicode_str,
+            },
+            'headers': {
+                'Host': '127.0.0.1',
+                'x-amz-content-sha256': unicode_str,
+                unicode_str: unicode_str,
+                u'foo': u'bar',
+            },
+            'body': unicode_str,
+            'fields': {},
+            'do_add_auth': 1
+        }
+        request3 = request.Request(dict3)
+        ctx = request3.aws_sign(unicode_str, unicode_str, headers_not_to_sign=[unicode_str],
+                                request_date=u'20190101T120000Z', region=unicode_str, service=u's3',
+                                signing_date=u'20180101', sign_payload=True)
+
+        self.assertEqual(unicode_str.encode('utf-8'),
+                         request3['headers']['X-Amz-Content-SHA256'])
+        self.assertIsInstance(request3['headers']['Authorization'], str)
+        self.assertIsInstance(request3['headers']['X-Amz-Date'], str)
+        self.assertEqual('20190101T120000Z', ctx['request_date'])
+        self.assertEqual(
+            'foo;host;x-amz-content-sha256;x-amz-date', ctx['signed_headers'])

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -18,7 +18,6 @@ class TestRequest(unittest.TestCase):
             'headers': {
                 'host': '127.0.0.1',
             },
-            'body': '',
             'fields': {},
             'sign_args': {
                 'access_key': 'access_key',
@@ -46,7 +45,6 @@ class TestRequest(unittest.TestCase):
             'headers': {
                 'host': '127.0.0.1',
             },
-            'body': '',
             'fields': {
                 'key': 'test_key',
                 'Policy': {
@@ -93,7 +91,6 @@ class TestRequest(unittest.TestCase):
                 unicode_str: unicode_str,
                 u'foo': u'bar',
             },
-            'body': '',
             'fields': {},
             'sign_args': {
                 'access_key': unicode_str,

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-# coding:utf-8
+# coding: utf-8
 
 import unittest
 
@@ -77,7 +77,7 @@ class TestRequest(unittest.TestCase):
                          request2['fields']['Policy'])
 
         dict3 = {
-            'verb': 'GET',
+            'verb': 'PUT',
             'uri': '/',
             'args': {
                 'foo': 'haha',
@@ -98,10 +98,10 @@ class TestRequest(unittest.TestCase):
 
         self.assertEqual('/?acl&foo=haha', request3['uri'])
         self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180930/us-east-1/s3/aws4_request, '
-                          'SignedHeaders=host;x-amz-content-sha256;x-amz-date, '
-                          'Signature=84e24cb298eb2438bea2c2308adc699798edef44d02d8e3cd7b75acf6c8f8bc2'),
+                          'SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, '
+                          'Signature=9c4e4cbe1b58958e9e026c404b0a54ae107e5a90fd2870f31f6d207216e2c4e8'),
                          request3['headers']['Authorization'])
-        self.assertEqual('UNSIGNED-PAYLOAD',request3['headers']['X-Amz-Content-SHA256'])
+        self.assertEqual('UNSIGNED-PAYLOAD', request3['headers']['X-Amz-Content-SHA256'])
         self.assertEqual('20180930T120101Z', request3['headers']['X-Amz-Date'])
 
         dict4 = {
@@ -150,7 +150,7 @@ class TestRequest(unittest.TestCase):
             }
         }
 
-        request3 = request.Request(dict5, data=unicode_str)
+        request3 = request.Request(dict5)
 
         self.assertEqual(unicode_str.encode('utf-8'),
                          request3['headers']['X-Amz-Content-SHA256'])

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -20,12 +20,13 @@ class TestRequest(unittest.TestCase):
             },
             'body': 'foo',
             'fields': {},
-            'do_add_auth': True,
-            'sign_args': {'access_key': 'access_key', 'secret_key': 'secret_key',
-                          'request_date': '20180101T120101Z', 'sign_payload': True}
+            'sign_args': {'access_key': 'access_key',
+                          'secret_key': 'secret_key',
+                          'request_date': '20180101T120101Z',
+                          'sign_payload': True}
         }
 
-        request1 = request.Request(dict1)
+        request1 = request.Request(dict1, do_add_auth=True)
 
         self.assertEqual('/?acl&foo=bar', request1['uri'])
         self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180101/us-east-1/s3/aws4_request, '
@@ -56,12 +57,12 @@ class TestRequest(unittest.TestCase):
                     ],
                 },
             },
-            'do_add_auth': True,
-            'sign_args': {'access_key': 'access_key', 'secret_key': 'secret_key',
+            'sign_args': {'access_key': 'access_key',
+                          'secret_key': 'secret_key',
                           'request_date': '20180101T120101Z'}
         }
 
-        request2 = request.Request(dict2)
+        request2 = request.Request(dict2, do_add_auth=True)
 
         self.assertEqual('AWS4-HMAC-SHA256', request2['fields']['X-Amz-Algorithm'])
         self.assertEqual('20180101T120101Z', request2['fields']['X-Amz-Date'])
@@ -90,14 +91,17 @@ class TestRequest(unittest.TestCase):
             },
             'body': unicode_str,
             'fields': {},
-            'do_add_auth': 1,
-            'sign_args': {'access_key': unicode_str, 'secret_key': unicode_str,
-                          'headers_not_to_sign': [unicode_str], 'region': unicode_str,
-                          'request_date': u'20190101T120000Z', 'service': u's3',
-                          'signing_date': u'20180101', 'sign_payload': True}
+            'sign_args': {'access_key': unicode_str,
+                          'secret_key': unicode_str,
+                          'headers_not_to_sign': [unicode_str],
+                          'region': unicode_str,
+                          'request_date': u'20190101T120000Z',
+                          'service': u's3',
+                          'signing_date': u'20180101',
+                          'sign_payload': True}
         }
 
-        request3 = request.Request(dict3)
+        request3 = request.Request(dict3, do_add_auth=True)
 
         self.assertEqual(unicode_str.encode('utf-8'),
                          request3['headers']['X-Amz-Content-SHA256'])

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -20,13 +20,15 @@ class TestRequest(unittest.TestCase):
             },
             'body': 'foo',
             'fields': {},
-            'sign_args': {'access_key': 'access_key',
-                          'secret_key': 'secret_key',
-                          'request_date': '20180101T120101Z',
-                          'sign_payload': True}
+            'sign_args': {
+                'access_key': 'access_key',
+                'secret_key': 'secret_key',
+                'request_date': '20180101T120101Z',
+                'sign_payload': True,
+            }
         }
 
-        request1 = request.Request(dict1, do_add_auth=True)
+        request1 = request.Request(dict1)
 
         self.assertEqual('/?acl&foo=bar', request1['uri'])
         self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180101/us-east-1/s3/aws4_request, '
@@ -57,12 +59,14 @@ class TestRequest(unittest.TestCase):
                     ],
                 },
             },
-            'sign_args': {'access_key': 'access_key',
-                          'secret_key': 'secret_key',
-                          'request_date': '20180101T120101Z'}
+            'sign_args': {
+                'access_key': 'access_key',
+                'secret_key': 'secret_key',
+                'request_date': '20180101T120101Z',
+            }
         }
 
-        request2 = request.Request(dict2, do_add_auth=True)
+        request2 = request.Request(dict2)
 
         self.assertEqual('AWS4-HMAC-SHA256', request2['fields']['X-Amz-Algorithm'])
         self.assertEqual('20180101T120101Z', request2['fields']['X-Amz-Date'])
@@ -91,17 +95,19 @@ class TestRequest(unittest.TestCase):
             },
             'body': unicode_str,
             'fields': {},
-            'sign_args': {'access_key': unicode_str,
-                          'secret_key': unicode_str,
-                          'headers_not_to_sign': [unicode_str],
-                          'region': unicode_str,
-                          'request_date': u'20190101T120000Z',
-                          'service': u's3',
-                          'signing_date': u'20180101',
-                          'sign_payload': True}
+            'sign_args': {
+                'access_key': unicode_str,
+                'secret_key': unicode_str,
+                'headers_not_to_sign': [unicode_str],
+                'region': unicode_str,
+                'request_date': u'20190101T120000Z',
+                'service': u's3',
+                'signing_date': u'20180101',
+                'sign_payload': True,
+            }
         }
 
-        request3 = request.Request(dict3, do_add_auth=True)
+        request3 = request.Request(dict3)
 
         self.assertEqual(unicode_str.encode('utf-8'),
                          request3['headers']['X-Amz-Content-SHA256'])

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python2
+# coding:utf-8
+
+import unittest
+
+from pykit import request
+
+
+class TestRequest(unittest.TestCase):
+    def test_aws_sign(self):
+        dict1 = {
+            'verb': 'GET',
+            'uri': '/',
+            'args': {
+                'foo': 'bar',
+                'acl': True,
+            },
+            'headers': {
+                'host': '127.0.0.1',
+            },
+            'body': 'foo',
+            'fields': {},
+            'do_add_auth': True
+        }
+        request1 = request.Request(dict1)
+        request1.aws_sign('access_key', 'secret_key', sign_payload=True, request_date='20180101T120101Z')
+
+        self.assertEqual('/?acl&foo=bar', request1['uri'])
+        self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180101/us-east-1/s3/aws4_request, '
+                          'SignedHeaders=host;x-amz-content-sha256;x-amz-date, '
+                          'Signature=c0b1d89ddd41df96454d3a5e2c82afdc44aa19bc6593d4fa54bc277756dcc3ef'),
+                         request1['headers']['Authorization'])
+        self.assertEqual('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+                         request1['headers']['X-Amz-Content-SHA256'])
+        self.assertEqual('20180101T120101Z', request1['headers']['X-Amz-Date'])
+
+        dict2 = {
+            'verb': 'POST',
+            'uri': '/',
+            'args': {},
+            'headers': {
+                'host': '127.0.0.1',
+            },
+            'body': '',
+            'fields': {
+                'key': 'test_key',
+                'Policy': {
+                    'expiration': '2018-01-01T12:00:00.000Z',
+                    'condition': [
+                        ['starts-with', '$key', ''],
+                        {
+                            'bucket': 'test-bucket',
+                        },
+                    ],
+                },
+            },
+            'do_add_auth': True
+        }
+        request2 = request.Request(dict2)
+        request2.aws_sign('access_key', 'secret_key', request_date='20180101T120101Z')
+
+        self.assertEqual('AWS4-HMAC-SHA256', request2['fields']['X-Amz-Algorithm'])
+        self.assertEqual('20180101T120101Z', request2['fields']['X-Amz-Date'])
+        self.assertEqual('19235d229144aa2a1d2b1c3a842c96dfb76bca9b75286c2a0aaae8e29f45c5a7',
+                         request2['fields']['X-Amz-Signature'])
+        self.assertEqual('access_key/20180101/us-east-1/s3/aws4_request',
+                         request2['fields']['X-Amz-Credential'])
+        self.assertEqual(('eyJleHBpcmF0aW9uIjogIjIwMTgtMDEtMDFUMTI6MDA6MDAuMDAwWiIsICJjb25kaXRpb24i'
+                          'OiBbWyJzdGFydHMtd2l0aCIsICIka2V5IiwgIiJdLCB7ImJ1Y2tldCI6ICJ0ZXN0LWJ1Y2tldCJ9XX0='),
+                         request2['fields']['Policy'])

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -32,9 +32,9 @@ class TestRequest(unittest.TestCase):
         self.assertEqual('/?acl&foo=bar', request1['uri'])
         self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180101/us-east-1/s3/aws4_request, '
                           'SignedHeaders=host;x-amz-content-sha256;x-amz-date, '
-                          'Signature=c0b1d89ddd41df96454d3a5e2c82afdc44aa19bc6593d4fa54bc277756dcc3ef'),
+                          'Signature=206b5726935d40b8f6df695304b9bdae664694db30880ab33873bd7ff2e11b63'),
                          request1['headers']['Authorization'])
-        self.assertEqual('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+        self.assertEqual('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
                          request1['headers']['X-Amz-Content-SHA256'])
         self.assertEqual('20180101T120101Z', request1['headers']['X-Amz-Date'])
 

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -18,7 +18,7 @@ class TestRequest(unittest.TestCase):
             'headers': {
                 'host': '127.0.0.1',
             },
-            'body': 'foo',
+            'body': '',
             'fields': {},
             'sign_args': {
                 'access_key': 'access_key',
@@ -28,7 +28,7 @@ class TestRequest(unittest.TestCase):
             }
         }
 
-        request1 = request.Request(dict1)
+        request1 = request.Request(dict1, data='foo')
 
         self.assertEqual('/?acl&foo=bar', request1['uri'])
         self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180101/us-east-1/s3/aws4_request, '
@@ -93,7 +93,7 @@ class TestRequest(unittest.TestCase):
                 unicode_str: unicode_str,
                 u'foo': u'bar',
             },
-            'body': unicode_str,
+            'body': '',
             'fields': {},
             'sign_args': {
                 'access_key': unicode_str,
@@ -107,7 +107,7 @@ class TestRequest(unittest.TestCase):
             }
         }
 
-        request3 = request.Request(dict3)
+        request3 = request.Request(dict3, data=unicode_str)
 
         self.assertEqual(unicode_str.encode('utf-8'),
                          request3['headers']['X-Amz-Content-SHA256'])


### PR DESCRIPTION
### (做了啥)
设计request类用于http模块，并对request请求是否需要签名进行了区分，用request类实例化的对象（不管是否是签名请求）可以直接用于http发送请求。
- ..

### (实现意图)
封装request类，更易于使用，省去以前发送请求时需要调用其他模块得到body，headers等步骤。
将POST签名和非POST签名封装到了一个aws_sign函数中，省去以前分别调用不同签名函数的繁琐。
...

### (补充)
request类添加了do_add_auth字段标志是否是签名请求，对于非签名请求，直接提供合适dict后生成request对象就可用于http模块，对于签名请求，需要调用aws_sign（）函数更新request类中相应字段，然后即可用于http模块。对于POST请求，调用httpmultipart模块，使用multipart格式make_body和make_headers, 省得像以前一样，每次需要发送http post请求，需要调用httpmultipart模块先构建body和headers。
