### PR TITLE
request 类的设计

### DIFF
--- a/request/README.md
+++ b/request/README.md
@@ -1,0 +1,191 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+#   Table of Content
+
+- [Name](#name)
+- [Status](#status)
+- [Synopsis](#synopsis)
+- [Description](#description)
+- [Classes](#classes)
+  - [Request](#request)
+- [Author](#author)
+- [Copyright and License](#copyright-and-license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+#   Name
+
+request
+
+Represents a http request including a normal request and an aws version 4 signature request.
+
+#   Status
+
+This library is considered production ready.
+
+#   Synopsis
+
+```python
+#!/usr/bin/env python2
+# coding: utf-8
+
+from pykit import http
+from pykit.request import Request
+
+bucket_name = 'hu-by'
+key_name = 'hbykey'
+endpoint = 's2.lsl.com'
+
+# https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
+# Host must be in the format of destinationBucket.endpoint
+# you should add it in /etc/hosts
+host = bucket_name + '.' + endpoint
+port = 80
+
+access_key = 'u36vatc28bqy41oershl'
+secret_key = 'oTOZx9ONjXwOhqv6OMo1swa6eJECmf2d9xlqErdC'
+# create a suitable dict according to verb
+to_make_request = {
+    'verb': 'POST',
+    'uri': '/',
+    'headers': {
+        'Host': host,
+    },
+    'fields': {
+        'key': key_name,
+        'Policy': {
+            'expiration': '2019-09-30T12:00:00.000Z',
+            'conditions': [
+                ['starts-with', '$key', ''],
+                {
+                    'bucket': bucket_name,
+                },
+            ],
+        },
+    },
+    # arguments for adding aws version 4 signature
+    'sign_args': {
+        'access_key': access_key,
+        'secret_key': secret_key,
+        'request_date': '20180917T120101Z',
+    }
+}
+
+# body can be a file or str to upload
+signed_request = Request(to_make_request, body="a file or str")
+
+# send request
+conn = http.Client(host, port)
+conn.send_request(signed_request['uri'], method=signed_request['verb'], headers=signed_request['headers'])
+# signed_request['body'] is generator type
+for body in signed_request['body']:
+    conn.send_body(body)
+resp = conn.read_response()
+```
+
+#   Description
+
+Request represents a http request including a normal request and an aws version 4
+signature request. You need to provide a python dict (it typically contains `verb`,
+`uri`, `args`, `headers`, `fields`, `sign_args`) and body to upload if you need.
+Use request class to obtain a http request which can be sent directly. The obtained
+request typically includes `verb`, `uri`, `args`, `headers`, `body`, `fields`, `sign_args`.
+`body` is a generator object or empty str.
+
+#   Classes
+
+## Request
+
+**syntax**
+`Request(to_make_request, body=None)`
+
+**argument**
+
+-   `to_make_request`
+    a python dict which is used to obtain a request object.
+    It may contain the following fields:
+
+    -   `verb`:
+        the request method, such as `GET`, `PUT`, `POST`. Required.
+
+    -   `uri`:
+        the url encoded uri, it can contain query string only when
+        you did not specify `args` in `request`. Required.
+
+    -   `args`:
+        a python dict contains the request parameters, it should not be
+        url encoded. You can not use both `args` and query string in `uri`
+        at the same time. Generally this attribute is empty in post request.
+
+    -   `headers`:
+        a python dict contains request headers. It must contain the `Host` header.
+
+    -   `fields`: a python dict which contains form fields. Only the post
+        request fields is not empty, other situations fields is empty.
+        It may contain the following attributes:
+        
+        -   `Policy`:
+            is python dict, describing what is permitted in post request.
+            After the request being signed, it will be replaced by it's
+            base64 encoded version.
+
+        -   `key`:
+            the key of the object to upload.
+
+        It also support some other fields, more infomation at
+        [here](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html)
+        This method will add some signature related fields to this dict.
+
+    -   `sign_args`: a python dict which contains the args to add aws version 4 signature. It may
+        contain the following attributes:
+
+        -   `access_key`:
+            the access key used to sign the request.
+
+        -   `secret_key`:
+            the secret key used to sign the request.
+
+        -   `query_auth`:
+            set to `True` if you want to add the signature to the query string.
+            The default is `False`, mean add the signature in the header.
+            Generally, only non-post request may need it. Optional.
+
+        -   `sign_payload`:
+            set to `True` if you want to sign the payload.The default is `False`.
+            Generally, only non-post request may need it. Optional.
+
+        -   `headers_not_to_sign`:
+            a list of header names, used to indicate which headers are not
+            needed to be signed. Generally, only non-post request may need it. Optional.
+
+        -   `request_date`:
+            timestamp or a iso base format date string, used to specify
+            a custom request date, instead of using current time as request date.
+            Optional.
+
+        -   `signing_date`:
+            is a 8 digital date string like `20170131`, used to specify a
+            custom signing date. Optional.
+
+        -   `region`:
+            the region name of the service, the default is `us-east-1`.
+
+        -   `service`:
+            the service name, the default is `s3`.
+
+        -   `expires`:
+            specify the signature expire time in seconds.
+            It will overwrite the value of `default_expires`. Optional.
+
+-   `body`
+    represents a file or str to upload, being used to make body and content_length of the request.
+
+#   Author
+
+Hubiyong (胡碧勇) <biyong.hu@baishancloud.com>
+
+#   Copyright and License
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Hubiyong (胡碧勇) <biyong.hu@baishancloud.com>

--- a/request/__init__.py
+++ b/request/__init__.py
@@ -1,0 +1,16 @@
+from .request import (
+    Request,
+
+    RequestError,
+    InvalidRequestError,
+    InvalidArgumentError,
+)
+
+__all__ = [
+    'Request',
+
+    'RequestError'
+    'InvalidRequestError',
+    'InvalidArgumentError',
+
+]

--- a/request/example/send_request_example.py
+++ b/request/example/send_request_example.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+from pykit import http
+from pykit.request import Request
+
+if __name__ == '__main__':
+    bucket_name = 'your bucket name'
+    key_name = 'key name to upload'
+    endpoint = 's2 endpoint domain name'
+
+    # https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
+    # Host must be in the format of destinationBucket.endpoint
+    # you should add it in /etc/hosts
+    host = bucket_name + '.' + endpoint
+    port = 80
+
+    access_key = 'your access key'
+    secret_key = 'your secret key'
+    # send a post request
+    post_case = {
+        'verb': 'POST',
+        'uri': '/',
+        'headers': {
+            'Host': host,
+        },
+        'fields': {
+            'key': key_name,
+            'Policy': {
+                'expiration': '2018-09-30T12:00:00.000Z',
+                'conditions': [
+                    ['starts-with', '$key', ''],
+                    {
+                        'bucket': bucket_name,
+                    },
+                ],
+            },
+        },
+        'sign_args': {
+            'access_key': access_key,
+            'secret_key': secret_key,
+            'request_date': '20180918T120101Z',
+        }
+    }
+
+    signed_post = Request(post_case, body=open('./test.txt'))
+
+    conn = http.Client(host, port)
+    conn.send_request(signed_post['uri'], method=signed_post['verb'], headers=signed_post['headers'])
+    # signed_post['body'] is a generator object
+    for body in signed_post['body']:
+        conn.send_body(body)
+    print conn.read_response()
+
+    # send a put request
+    file_content = "test sending put request"
+    put_case = {
+        'verb': 'PUT',
+        'uri': '/bucket_name/key_name',
+        'args': {
+                'foo2': 'bar2',
+                'foo1': True,
+                'foo3': ['bar3', True],
+        },
+        'headers': {
+                'Host': host,
+        },
+        'sign_args': {
+            'access_key': access_key,
+            'secret_key': secret_key,
+            'sign_payload': True,
+        }
+    }
+
+    signed_put = Request(put_case, body=file_content)
+
+    conn = http.Client(host, port)
+    conn.send_request(signed_put['uri'], method=signed_put['verb'], headers=signed_put['headers'])
+    for body in signed_put['body']:
+        conn.send_body(body)
+    print conn.read_response

--- a/request/request.py
+++ b/request/request.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+import os
+from pykit import awssign
+from pykit import httpmultipart
+from pykit.dictutil import FixedKeysDict
+
+
+class RequestError(Exception):
+    pass
+
+
+class InvalidRequestError(RequestError):
+    pass
+
+
+class InvalidArgumentError(RequestError):
+    pass
+
+
+# the arg must be str or unicode type
+def _basestring(arg=''):
+
+    if not isinstance(arg, basestring):
+        raise InvalidArgumentError(
+            'type of arg should be str or unicode, but {t}'.format(t=type(arg)))
+
+    return arg
+
+
+def _get_sign_args(sign_args=None):
+
+    if sign_args is None:
+        return {}
+
+    if not isinstance(sign_args, dict):
+        raise InvalidArgumentError(
+            'type of sign_args should be dict, but {t}'.format(t=type(sign_args)))
+
+    if len(sign_args) == 0:
+        return {}
+
+    if 'access_key' not in sign_args:
+        raise InvalidArgumentError('add authorization request must contain access key')
+
+    if 'secret_key' not in sign_args:
+        raise InvalidArgumentError('add authorization request must contain secret key')
+
+    rst = {
+        'query_auth': False,
+        'sign_payload': False,
+        'headers_not_to_sign': [],
+        'request_date': None,
+        'signing_date': None,
+        'region': 'us-east-1',
+        'service': 's3',
+        'expires': 60,
+    }
+
+    rst.update(sign_args)
+
+    return rst
+
+
+def _make_post_body_headers(fields, headers, body):
+
+    multipart_cli = httpmultipart.Multipart()
+    multipart_fields = []
+
+    for k, v in fields.iteritems():
+        multipart_fields.append({'name': k, 'value': v})
+
+    if body is None:
+        multipart_fields.append({
+            'name': 'file',
+            'value': '',
+        })
+
+    elif isinstance(body, str):
+        multipart_fields.append({
+            'name': 'file',
+            'value': body,
+        })
+
+    elif isinstance(body, file):
+        multipart_fields.append({
+            'name': 'file',
+            'value': [body, os.fstat(body.fileno()).st_size, os.path.basename(body.name)],
+        })
+
+    else:
+        raise InvalidArgumentError(
+            'type of body should be str or file, but {t}'.format(t=type(body)))
+
+    body_reader = multipart_cli.make_body_reader(multipart_fields)
+
+    headers = multipart_cli.make_headers(multipart_fields, headers)
+
+    return body_reader, headers
+
+
+def _make_body_content_length(body):
+
+    if isinstance(body, str):
+        content_length = len(body)
+        body = _make_str_reader(body)
+
+    elif isinstance(body, file):
+        content_length = os.fstat(body.fileno()).st_size
+        body = _make_file_reader(body)
+
+    else:
+        raise InvalidArgumentError(
+            'type of body should be str or file, but {t}'.format(t=type(body)))
+
+    return body, content_length
+
+
+def _make_str_reader(body):
+    yield body
+
+
+def _make_file_reader(file_obj):
+    block_size = 1024 * 1024
+
+    while True:
+        buf = file_obj.read(block_size)
+        if buf == '':
+            break
+        yield buf
+
+
+def _get_body(body=None):
+    if body is None:
+        return ''
+
+    return body
+
+
+class Request(FixedKeysDict):
+
+    keys_default = dict((('verb', _basestring),
+                         ('uri', _basestring),
+                         ('args', dict),
+                         ('headers', dict),
+                         ('body', _get_body),
+                         ('fields', dict),
+                         ('sign_args', _get_sign_args),))
+
+    # body represents str or a file to upload
+    def __init__(self, to_make_request, body=None):
+
+        super(Request, self).__init__(to_make_request)
+
+        if self['body'] != '':
+            raise InvalidRequestError('body should be empty in provided dict')
+
+        if self['verb'] == 'POST':
+            if len(self['fields']) == 0:
+                raise InvalidRequestError('fields can not be empty in post request')
+
+        else:
+            if len(self['fields']) > 0:
+                raise InvalidRequestError('fields should be empty in non post request')
+
+            if body is not None:
+                self['body'], self['headers']['Content-Length'] = _make_body_content_length(body)
+
+            else:
+                self['headers']['Content-Length'] = 0
+
+        do_add_auth = (len(self['sign_args']) != 0)
+
+        if do_add_auth:
+            signer = awssign.Signer(self['sign_args']['access_key'],
+                                    self['sign_args']['secret_key'],
+                                    region=self['sign_args']['region'],
+                                    service=self['sign_args']['service'],
+                                    default_expires=self['sign_args']['expires'])
+
+        if self['verb'] == 'POST':
+            if do_add_auth:
+                signer.add_post_auth(self['fields'],
+                                     request_date=self['sign_args']['request_date'],
+                                     signing_date=self['sign_args']['signing_date'])
+
+            self['body'], self['headers'] = _make_post_body_headers(
+                self['fields'], self['headers'], body)
+
+        else:
+            if do_add_auth:
+                signer.add_auth(self, query_auth=self['sign_args']['query_auth'],
+                                sign_payload=self['sign_args']['sign_payload'],
+                                request_date=self['sign_args']['request_date'],
+                                signing_date=self['sign_args']['signing_date'],
+                                headers_not_to_sign=self['sign_args']['headers_not_to_sign'])

--- a/request/test/test_request.py
+++ b/request/test/test_request.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+import unittest
+from pykit.request import Request
+
+
+class TestRequest(unittest.TestCase):
+    def test_create_request(self):
+
+        get_case = {
+            'verb': 'GET',
+            'uri': '/',
+            'args': {
+                'foo': 'bar',
+                'acl': True,
+            },
+            'headers': {
+                'host': '127.0.0.1',
+            },
+            'sign_args': {
+                'access_key': 'access_key',
+                'secret_key': 'secret_key',
+                'request_date': '20180101T120101Z',
+                'sign_payload': True,
+            }
+        }
+
+        signed_get = Request(get_case, body='foo')
+
+        self.assertEqual('/?acl&foo=bar', signed_get['uri'])
+        self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180101/us-east-1/s3/aws4_request, '
+                          'SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, '
+                          'Signature=67b7e51a89e7bcb8d292272b940d3e040425c160e690c824d9e8d86616e843ae'),
+                         signed_get['headers']['Authorization'])
+        self.assertEqual('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+                         signed_get['headers']['X-Amz-Content-SHA256'])
+        self.assertEqual('20180101T120101Z', signed_get['headers']['X-Amz-Date'])
+
+        post_case = {
+            'verb': 'POST',
+            'uri': '/',
+            'headers': {
+                'host': '127.0.0.1',
+            },
+            'fields': {
+                'key': 'test_key',
+                'Policy': {
+                    'expiration': '2019-01-01T12:00:00.000Z',
+                    'conditions': [
+                        ['starts-with', '$key', ''],
+                        {
+                            'bucket': 'test-bucket',
+                        },
+                    ],
+                },
+            },
+            'sign_args': {
+                'access_key': 'access_key',
+                'secret_key': 'secret_key',
+                'request_date': '20180101T120101Z',
+            }
+        }
+
+        signed_post = Request(post_case)
+
+        self.assertEqual('AWS4-HMAC-SHA256', signed_post['fields']['X-Amz-Algorithm'])
+        self.assertEqual('20180101T120101Z', signed_post['fields']['X-Amz-Date'])
+        self.assertEqual('e78f45490d1e075bc7ea47841a3e084364dc69a3d13d21df3a3cb1f7b8df37ab',
+                         signed_post['fields']['X-Amz-Signature'])
+        self.assertEqual('access_key/20180101/us-east-1/s3/aws4_request',
+                         signed_post['fields']['X-Amz-Credential'])
+        self.assertEqual(('eyJjb25kaXRpb25zIjogW1sic3RhcnRzLXdpdGgiLCAiJGtleS'
+                          'IsICIiXSwgeyJidWNrZXQiOiAidGVzdC1idWNrZXQifV0sICJl'
+                          'eHBpcmF0aW9uIjogIjIwMTktMDEtMDFUMTI6MDA6MDAuMDAwWiJ9'),
+                         signed_post['fields']['Policy'])
+
+        put_case = {
+            'verb': 'PUT',
+            'uri': '/',
+            'args': {
+                'foo': 'haha',
+                'acl': True,
+            },
+            'headers': {
+                'host': '127.0.0.1',
+            },
+            'sign_args': {
+                'access_key': 'access_key',
+                'secret_key': 'secret_key',
+                'request_date': '20180930T120101Z',
+                'sign_payload': False,
+            }
+        }
+
+        signed_put = Request(put_case)
+
+        self.assertEqual('/?acl&foo=haha', signed_put['uri'])
+        self.assertEqual(('AWS4-HMAC-SHA256 Credential=access_key/20180930/us-east-1/s3/aws4_request, '
+                          'SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, '
+                          'Signature=9c4e4cbe1b58958e9e026c404b0a54ae107e5a90fd2870f31f6d207216e2c4e8'),
+                         signed_put['headers']['Authorization'])
+        self.assertEqual('UNSIGNED-PAYLOAD', signed_put['headers']['X-Amz-Content-SHA256'])
+        self.assertEqual('20180930T120101Z', signed_put['headers']['X-Amz-Date'])
+
+        no_sign_args_put = {
+            'verb': 'PUT',
+            'uri': '/',
+            'args': {
+                'foo': 'bar',
+                'acl': True,
+            },
+            'headers': {
+                'host': '127.0.0.1',
+            },
+        }
+
+        not_signed_put = Request(no_sign_args_put, body='test request')
+        self.assertEqual(12, not_signed_put['headers']['Content-Length'])
+
+        for body in not_signed_put['body']:
+            res_body = body
+
+        self.assertEqual('test request', res_body)
+
+    def test_unicode(self):
+        unicode_str = '测试'.decode('utf-8')
+        unicode_get_case = {
+            'verb': u'GET',
+            'uri': '/' + unicode_str,
+            'args': {
+                unicode_str: unicode_str,
+            },
+            'headers': {
+                'Host': '127.0.0.1',
+                'x-amz-content-sha256': unicode_str,
+                unicode_str: unicode_str,
+                u'foo': u'bar',
+            },
+            'sign_args': {
+                'access_key': unicode_str,
+                'secret_key': unicode_str,
+                'headers_not_to_sign': [unicode_str],
+                'region': unicode_str,
+                'request_date': u'20190101T120000Z',
+                'service': u's3',
+                'signing_date': u'20180101',
+                'sign_payload': True,
+            }
+        }
+
+        signed_get = Request(unicode_get_case)
+
+        self.assertEqual(unicode_str.encode('utf-8'),
+                         signed_get['headers']['X-Amz-Content-SHA256'])
+        self.assertIsInstance(signed_get['headers']['Authorization'], str)
+        self.assertIsInstance(signed_get['headers']['X-Amz-Date'], str)


### PR DESCRIPTION
### (做了啥)
设计request类用于http模块，用request类实例化的对象（不管是否是签名请求）可以直接用于http发送请求。

### (实现意图)
封装request类，更易于使用，省去以前发送请求时需要调用其他模块得到body，headers等步骤。
给出签名参数即及request相关参数即可得到签名请求，不用单独调用其他函数进行签名。