### PR TITLE
fix zktx record and journal acl bug

### DIFF
--- a/zktx/test/test_tx.py
+++ b/zktx/test/test_tx.py
@@ -628,6 +628,20 @@ class TestTX(TXBase):
         except CommitError:
             pass
 
+    def test_acl(self):
+        k = 'tacl'
+        with ZKTransaction(self.zkauthed) as t1:
+            foo = t1.lock_get(k)
+            foo.v = 'foo'
+            t1.set(foo)
+            t1.commit()
+
+            acls, _ = self.zk.get_acls(self.zkauthed._zkconf.record(k))
+            self.assertEqual(self.zkauthed._zkconf.kazoo_digest_acl(), acls)
+
+            acls, _ = self.zk.get_acls(self.zkauthed._zkconf.journal(0))
+            self.assertEqual(self.zkauthed._zkconf.kazoo_digest_acl(), acls)
+
 
 class TestTXState(TXBase):
 

--- a/zktx/zktx.py
+++ b/zktx/zktx.py
@@ -345,7 +345,8 @@ class ZKTransaction(object):
 
             if curr.version == -1:
                 kazootx.create(cnf.record(rec.k),
-                               utfjson.dump(record_vals))
+                               utfjson.dump(record_vals),
+                               acl=cnf.kazoo_digest_acl())
             else:
                 kazootx.set_data(cnf.record(rec.k),
                                  utfjson.dump(record_vals),
@@ -362,7 +363,10 @@ class ZKTransaction(object):
             # provide a str "journal_id", because
             # kazootx.create('xx/', '', sequence=True) => xx0000000000
             # kazootx.create('xx/a', '', sequence=True) => xx/a0000000000
-            kazootx.create(cnf.journal("journal_id"), utfjson.dump(jour), sequence=True)
+            kazootx.create(cnf.journal("journal_id"),
+                           utfjson.dump(jour),
+                           acl=cnf.kazoo_digest_acl(),
+                           sequence=True)
             rst = kazootx.commit()
             for r in rst:
                 if isinstance(r, KazooException):

--- a/zkutil/zkconf.py
+++ b/zkutil/zkconf.py
@@ -201,7 +201,9 @@ def kazoo_client_ext(zk, json=True):
         owning = True
 
     zkclient = KazooClientExt(zk, json=json)
-    zkclient._zkconf = zkconf
+
+    if zkclient._zkconf is None:
+        zkclient._zkconf = zkconf
 
     zkclient.start()
 


### PR DESCRIPTION
### (做了啥)

- 修复record和journal缺失acl的问题
- 修复kazoo_client_ext当参数是KazooClientExt的时候zkconf被覆盖的问题

### (实现意图)

Fix: #xxx
