### PR TITLE
ectypes: improve xxID: add embedded attribute and self ref attribute

### DIFF
--- a/ectypes/README.md
+++ b/ectypes/README.md
@@ -320,6 +320,8 @@ class MyID(IDBase):
 Here we have two attribute `foo` and `bar` and two **alias** attributes `alias1`
 and `alias2`.
 
+#### Non key-attribute
+
 To declare an alias attribute, add a fifth field as attribute options:
 `{'key_attr': False}` or just a `False` as shortcut.
 
@@ -332,6 +334,49 @@ MyID('12')
 MyID('1', '2')
 MyID('1', bar='2')
 MyID(foo='1', bar='2')
+```
+
+#### Self attribute
+
+To declare a **self** attribute, which reference the instance itself, use opt:
+`{'self': True}` or `'self'` as a shortcut.
+
+```
+class MyID(IDBase):
+    _attrs = (
+        ('foo',    0,  1, str),
+        ('me',     None,  None, None, 'self'),
+    _str_len = 1
+
+i = MyID('a')
+print i is i.me    # True
+print i is i.me.me # True
+```
+
+
+#### Embedded attribute
+
+To embed sub-attributes, use opt:
+`{'embed': True}` or `'embed'` as shortcut:
+
+```
+class SubID1(IDBase):
+    _attrs = (
+        ('one',  0,  1, lambda x: 1),
+    )
+    _str_len = 1
+
+
+class MyID(IDBase):
+    _attrs = (
+        ('foo',  0,  1, str),
+        ('sub',  1,  2, SubID1, 'embed'),
+    )
+    _str_len = 2
+
+i = MyID('ab')
+print i.sub.one     # 1
+print i.one         # 1
 ```
 
 
@@ -395,10 +440,10 @@ A subclass of `IDBase`. Make a drive id, format: 16 chars
 
 **arguments**:
 
-    `server_id`:
+-   `server_id`:
     A string, Format: 18 chars of idc and primary MAC addr.
 
-    `mount_point_index`:
+-   `mount_point_index`:
     It is a 3-digit mount path, `001` for `/drives/001`.
 
 
@@ -408,6 +453,8 @@ from pykit import ectypes
 print ectypes.DriveID('idc000' 'aabbccddeeff', 10)
 # out: aabbccddeeff0010
 ```
+
+`DriveID` embeds `ServerID` attributes.
 
 
 ##  ectypes.BlockID
@@ -430,6 +477,9 @@ print bid.block_id_seq    # 1
 # test __str__()
 print bid                 # d0g0006300000001230101idc000c62d8736c72800020000000001
 ```
+
+`BlockID` embeds `DriveID` attributes.
+
 
 ### block id
 

--- a/ectypes/block_id.py
+++ b/ectypes/block_id.py
@@ -13,8 +13,10 @@ class BlockID(IDBase):
         ('type',           0,  2,  str),
         ('block_group_id', 2,  18, BlockGroupID),
         ('block_index',    18, 22, BlockIndex),
-        ('drive_id',       22, 44, DriveID),
+        ('drive_id',       22, 44, DriveID, 'embed'),
         ('block_id_seq',   44, 54, int),
+
+        ('block_id',       None, None, None, 'self'),
     )
 
     _str_len = 54

--- a/ectypes/drive_id.py
+++ b/ectypes/drive_id.py
@@ -21,10 +21,12 @@ def _port(s):
 class DriveID(IDBase):
 
     _attrs = (
-        ('server_id', 0, 18, ServerID),
+        ('server_id', 0, 18, ServerID, 'embed'),
         ('_padding_0', 18, 19, _padding_0),
         ('mountpoint_index', 19, 22, MountPointIndex),
         ('port', 19 ,22, _port, False),
+
+        ('drive_id', None, None, None, 'self'),
     )
 
     _str_len = 22

--- a/ectypes/server_id.py
+++ b/ectypes/server_id.py
@@ -21,6 +21,8 @@ class ServerID(IDBase):
     _attrs = (
             ('idc_id', 0, IDC_ID_LEN, IDCID), 
             ('mac_addr', IDC_ID_LEN, IDC_ID_LEN + SERVER_ID_LEN, _mac_addr),
+
+            ('server_id', None, None, None, 'self'),
     )
 
     _str_len = IDC_ID_LEN + SERVER_ID_LEN

--- a/ectypes/test/test_block_id.py
+++ b/ectypes/test/test_block_id.py
@@ -28,6 +28,31 @@ class TestBlockID(unittest.TestCase):
         self.assertEqual('idc000' 'c62d8736c7280002', bid.drive_id)
         self.assertEqual(1, bid.block_id_seq)
 
+    def test_block_id_block_id(self):
+
+        block_id = 'd1g0006300000001230101idc000c62d8736c72800020000000001'
+        bid = BlockID('d1', 'g000630000000123', '0101',
+                      DriveID('idc000' 'c62d8736c728' '0002'), 1)
+
+        self.assertEqual('d1g0006300000001230101idc000c62d8736c72800020000000001', bid.block_id)
+        self.assertEqual(block_id, bid.block_id)
+        self.assertIs(bid, bid.block_id)
+
+    def test_block_id_embed(self):
+
+        block_id = 'd1g0006300000001230101idc000c62d8736c72800020000000001'
+        bid = BlockID('d1', 'g000630000000123', '0101',
+                      DriveID('idc000' 'c62d8736c728' '0002'), 1)
+
+        # embedded drive_id attrs
+        self.assertEqual('idc000' 'c62d8736c728', bid.server_id)
+        self.assertEqual('002', bid.mountpoint_index)
+        self.assertEqual(6002, bid.port)
+
+        # embedded server_id attrs
+        self.assertEqual('idc000', bid.idc_id)
+        self.assertEqual('c62d8736c728', bid.mac_addr)
+
     def test_new_invalid(self):
 
         block_id_invalid = 'd1g0006300000001230101idc000c62d8736c728000200000'

--- a/ectypes/test/test_drive_id.py
+++ b/ectypes/test/test_drive_id.py
@@ -64,6 +64,17 @@ class TestDriveID(unittest.TestCase):
             self.assertEqual(6001, drive_id.port)
             self.assertEqual('idc0001122334455660001', str(drive_id))
 
+    def test_drive_id_self(self):
+        d = DriveID('idc0001122334455660001')
+        self.assertEqual('idc0001122334455660001', d.drive_id)
+        self.assertEqual(d, d.drive_id)
+        self.assertIs(d, d.drive_id)
+
+    def test_drive_id_embed(self):
+        d = DriveID('idc000' '112233445566' '0001')
+        self.assertEqual('idc000', d.idc_id)
+        self.assertEqual('112233445566', d.mac_addr)
+
     def test_validate_drive_id(self):
         invalid_cases = (
             (),

--- a/ectypes/test/test_idbase.py
+++ b/ectypes/test/test_idbase.py
@@ -93,17 +93,35 @@ class TestIDBase(unittest.TestCase):
             block_index = BlockIndex(i='01', j='345')
 
 
+class SubID1(IDBase):
+    _attrs = (
+        ('a',  0,  1, lambda x: 1),
+    )
+    _str_len = 1
+
+
+class SubID2(IDBase):
+    _attrs = (
+        ('b',  0,  1, lambda x: 2),
+    )
+    _str_len = 1
+
 class NonKeyID(IDBase):
     _attrs = (
         ('foo',  0,  1, str),
-        ('foo2', 1,  2, str),
+        ('sub1', 1,  2, SubID1, 'embed'),
+        ('sub2', 1,  2, SubID2, {'embed': True, 'key_attr': False}),
+
         ('bar',  1,  2, str, False),
         ('wow',  1,  2, str, {'key_attr': False}),
+
+        ('me',   1,  2, str, 'self'),
+        ('me2',  1,  2, str, {'self': True}),
     )
 
     _str_len = 2
 
-    _tostr_fmt = '{foo}{foo2}'
+    _tostr_fmt = '{foo}{sub1}'
 
 
 class TestNonKeyAttr(unittest.TestCase):
@@ -111,17 +129,27 @@ class TestNonKeyAttr(unittest.TestCase):
     def test_non_key_attr(self):
 
         s = NonKeyID('12')
-        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.foo2, s.bar, s.wow))
+        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.sub1, s.bar, s.wow))
 
         s = NonKeyID('1', '2')
-        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.foo2, s.bar, s.wow))
+        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.sub1, s.bar, s.wow))
 
-        s = NonKeyID('1', foo2='2')
-        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.foo2, s.bar, s.wow))
+        s = NonKeyID('1', sub1='2')
+        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.sub1, s.bar, s.wow))
 
-        s = NonKeyID(foo='1', foo2='2')
-        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.foo2, s.bar, s.wow))
+        s = NonKeyID(foo='1', sub1='2')
+        self.assertEqual(('12', '1', '2', '2', '2'), (s, s.foo, s.sub1, s.bar, s.wow))
 
     def test_as_tuple(self):
         s = NonKeyID('12')
         self.assertEqual(('1', '2'), s.as_tuple())
+
+    def test_self(self):
+        s = NonKeyID('12')
+        self.assertIs(s, s.me)
+        self.assertIs(s, s.me2)
+
+    def test_embed(self):
+        s = NonKeyID('12')
+        self.assertEqual(1, s.a)
+        self.assertEqual(2, s.b)

--- a/ectypes/test/test_server_id.py
+++ b/ectypes/test/test_server_id.py
@@ -62,6 +62,10 @@ class TestServerID(unittest.TestCase):
             sid = ectypes.ServerID(_idcid + c)
             self.assertEqual(_idcid + c, sid)
 
+    def test_server_id_self(self):
+        sid = ectypes.ServerID('idc000' '112233aabbcc')
+        self.assertIs(sid, sid.server_id)
+
     def test_server_id_to_str(self):
 
         sid = ectypes.ServerID.local_server_id(_idcid)


### PR DESCRIPTION
方便id的属性访问, 现在可以支持:

```
ServerID(..).server_id
DriveID(..).server_id
BlockID(..).server_id

ServerID(..).idc_id
DriveID(..).idc_id
BlockID(..).idc_id
```