### PR TITLE
strutil.Hex to simplify operation for crc32, sha1 etc

### DIFF
--- a/strutil/README.md
+++ b/strutil/README.md
@@ -17,6 +17,8 @@
     - [TrieNode.char](#trienodechar)
     - [TrieNode.outstanding](#trienodeoutstanding)
     - [TrieNode.is_outstanding](#trienodeis_outstanding)
+  - [strutil.Hex](#strutilhex)
+    - [Hex instance attributes](#hex-instance-attributes)
 - [Methods](#methods)
   - [strutil.break_line](#strutilbreak_line)
   - [strutil.color](#strutilcolor)
@@ -293,6 +295,96 @@ This attribute points to the last added child node.
 
 If this node is an outstanding node to its parent node.  When created, a node
 must be an outstanding node.
+
+
+##  strutil.Hex
+
+**syntax**:
+`strutil.Hex(data, byte_length)`
+
+Create a `str` based instance that represents a fixed-length hex string,
+to simplify hex and arithmetic operations.
+
+An `Hex` instance supports arithmetic operations: `+ - * / % **`.
+
+NOTE: **it overrides native `str` operation such as `str + str`**.
+
+**arguments**:
+
+-   `data`:
+    can be a `str`, `int` or tuple in form of `(<prefix_hex>, <filling_byte>)`
+
+-   `byte_length`:
+    specifies number of bytes for this hex.
+    It can not be changed after creating it.
+
+    > byte length x 2 = hex length
+
+    It also can be a symblic name: `crc32`, `md5`, `sha1` or `sha256`.
+
+**Synopsis**:
+
+```python
+from pykit.strutil import Hex
+
+
+# Different ways to create a 4-byte crc32 hex str
+
+Hex(0x0102, 4)           # 00000102
+Hex(0x0102, 'crc32')     # 00000102
+Hex.crc32(0x0102)        # 00000102
+Hex('00000102', 'crc32') # 00000102
+Hex.crc32('00000102')    # 00000102
+
+
+# Create with a tuple of prefix and a filling byte
+
+Hex(('12', 1), 'crc32')  # 12010101
+
+
+# Arithmetic operations
+
+c = Hex(0x0102, 'crc32')
+d = c + 1
+print type(d), d         # <class 'pykit.strutil.hex.Hex'> 00000006
+print repr(c*2)          # '00000204'
+print c - 1000000        # 00000000 # overflow protection
+print c * 1000000        # ffffffff # overflow protection
+
+
+# Iterate over sha1 space with a specific step:
+
+c = Hex.sha1(0)
+step = Hex.sha1(('10', 0))
+for i in range(16):
+    print c
+    c += step
+
+# 0000000000000000000000000000000000000000
+# 1000000000000000000000000000000000000000
+# 2000000000000000000000000000000000000000
+# 3000000000000000000000000000000000000000
+# 4000000000000000000000000000000000000000
+# 5000000000000000000000000000000000000000
+# 6000000000000000000000000000000000000000
+# 7000000000000000000000000000000000000000
+# 8000000000000000000000000000000000000000
+# 9000000000000000000000000000000000000000
+# a000000000000000000000000000000000000000
+# b000000000000000000000000000000000000000
+# c000000000000000000000000000000000000000
+# d000000000000000000000000000000000000000
+# e000000000000000000000000000000000000000
+# f000000000000000000000000000000000000000
+
+```
+
+###  Hex instance attributes
+
+-   `Hex.hex`: a plain string of hex `'00000102'`.
+-   `Hex.bytes`: a plain string of bytes `'\0\0\1\2'`.
+-   `Hex.int`: a int value `0x0102` same as `int('00000102', 16)`.
+-   `Hex.byte_length`: number of bytes in `Hex.bytes`.
 
 
 #   Methods

--- a/strutil/__init__.py
+++ b/strutil/__init__.py
@@ -34,6 +34,10 @@ from .colored_string import (
     fading_color,
 )
 
+from .hex import (
+    Hex
+)
+
 from .trie import (
     TrieNode,
     make_trie,
@@ -67,6 +71,8 @@ __all__ = [
     'danger',
 
     'fading_color',
+
+    'Hex',
 
     'struct_repr',
     'format_table',

--- a/strutil/hex.py
+++ b/strutil/hex.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+
+class Hex(str):
+
+    byte_length = None
+
+    lengths = dict(
+        crc32=4,
+        md5=16,
+        sha1=20,
+        sha256=32,
+    )
+
+    def __new__(clz, data, byte_length=None):
+
+        if byte_length is None:
+            byte_length = clz.byte_length
+
+            assert byte_length is not None
+
+        if isinstance(byte_length, str):
+            # convert named length to number
+            b = byte_length.lower()
+            byte_length = clz.lengths[b]
+
+        if isinstance(data, (list, tuple)):
+            data, fillwith = data
+
+            assert isinstance(fillwith, (int, long))
+            assert 0 <= fillwith <= 0xff
+            assert isinstance(data, str)
+            assert len(data) % 2 == 0
+
+            data += ('%02x' % fillwith) * (byte_length - len(data) / 2)
+
+        if isinstance(data, (int, long)):
+            if data < 0:
+                raise ValueError('int/long must be positive but: ' + repr(data))
+
+            data = '%0{n}x'.format(n=byte_length*2) % data
+
+        if not isinstance(data, str):
+            raise TypeError('exptect str or int/long, but: ' + type(data))
+
+        if len(data) == byte_length * 2:
+            # new from hex string
+            _hex = data
+        elif len(data) == byte_length:
+            _hex = data.encode('hex')
+        else:
+            raise ValueError('str data length must be {l2} for hex,'
+                             ' or {l} for byte,'
+                             ' but: {act}'.format(
+                                 l=byte_length,
+                                 l2=byte_length*2,
+                                 act=len(data)))
+
+        _bytes = _hex.decode('hex')
+        _long = int(_hex, 16)
+
+        x = super(Hex, clz).__new__(clz, _hex)
+        x.hex = _hex
+        x.bytes = _bytes
+        x.int = _long
+        x.byte_length = byte_length
+
+        return x
+
+    def __add__(self, b):
+        return self._arithm(self.int + self._tolong(b))
+
+    def __sub__(self, b):
+        return self._arithm(self.int - self._tolong(b))
+
+    def __mul__(self, b):
+        return self._arithm(self.int * self._tolong(b))
+
+    def __div__(self, b):
+        return self._arithm(self.int / self._tolong(b))
+
+    def __mod__(self, b):
+        return self._arithm(self.int % self._tolong(b))
+
+    def __pow__(self, b):
+        return self._arithm(self.int ** self._tolong(b))
+
+    def _tolong(self, x):
+        if isinstance(x, self.__class__):
+            return x.int
+        elif isinstance(x, (int, long)):
+            return x
+        else:
+            raise TypeError(str(type(self)) + ' does not support arithmetic operation with {b}'.format(b=repr(x)))
+
+    def _arithm(self, x):
+        if x < 0:
+            x = 0
+
+        if x >= 256 ** self.byte_length:
+            x = 256 ** self.byte_length - 1
+
+        return self.__class__(x, self.byte_length)
+
+    def __str__(self):
+        return self.hex
+
+    @classmethod
+    def crc32(clz, data): return clz(data, 'crc32')
+
+    @classmethod
+    def md5(clz, data): return clz(data, 'md5')
+
+    @classmethod
+    def sha1(clz, data): return clz(data, 'sha1')
+
+    @classmethod
+    def sha256(clz, data): return clz(data, 'sha256')

--- a/strutil/test/test_hex.py
+++ b/strutil/test/test_hex.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python2
+# coding: utf-8
+
+import os
+import unittest
+
+from pykit import strutil
+from pykit.strutil import Hex
+from pykit import ututil
+from pykit import utfjson
+
+dd = ututil.dd
+
+
+class TestHex(unittest.TestCase):
+
+    def test_init(self):
+
+        byte_length = 3
+
+        cases = (
+                (0, 0),
+                ('000000', 0),
+                ('\0\0\0', 0),
+
+                (256**2 + 2*256 + 3, 0x010203),
+                ('010203', 0x010203),
+                ('\1\2\3', 0x010203),
+        )
+
+        for inp, expected in cases:
+            dd(inp, expected)
+            c = Hex(inp, byte_length)
+            self.assertEqual(expected, c.int)
+            self.assertEqual('%06x' % expected, c)
+
+    def test_attr(self):
+        c = Hex('010203', 3)
+        self.assertEqual('010203', c.hex)
+        self.assertEqual('\1\2\3', c.bytes)
+        self.assertEqual(256**2 + 2*256 + 3, c.int)
+
+        self.assertIs('010203', c.hex)
+        self.assertIsNot('010203', c)
+
+    def test_init_invalid(self):
+
+        byte_length = 3
+
+        cases = (
+                (256**3-1,   None),
+                (256**3,     ValueError),
+                (-1,         ValueError),
+                ('\1\2',     ValueError),
+                ('\1\2\3\4', ValueError),
+                ('0102',     ValueError),
+                ('01020',    ValueError),
+                ('0102030',  ValueError),
+                ('01020304', ValueError),
+
+                ({}, TypeError),
+        )
+
+        for inp, err in cases:
+            dd(inp, err)
+            if err is None:
+                c = Hex(inp, byte_length)
+            else:
+                self.assertRaises(err, Hex, inp, byte_length)
+
+    def test_named_length(self):
+        val = 0x010203
+        cases = (
+            ('crc32',  '00010203'),
+            ('Crc32',  '00010203'),
+            ('CRC32',  '00010203'),
+            ('md5',    '00000000000000000000000000010203'),
+            ('Md5',    '00000000000000000000000000010203'),
+            ('MD5',    '00000000000000000000000000010203'),
+            ('sha1',   '0000000000000000000000000000000000010203'),
+            ('Sha1',   '0000000000000000000000000000000000010203'),
+            ('SHA1',   '0000000000000000000000000000000000010203'),
+            ('sha256', '0000000000000000000000000000000000000000000000000000000000010203'),
+            ('Sha256', '0000000000000000000000000000000000000000000000000000000000010203'),
+            ('SHA256', '0000000000000000000000000000000000000000000000000000000000010203'),
+        )
+
+        for typ, expected in cases:
+            c = Hex(val, typ)
+            self.assertEqual(expected, c)
+
+    def test_checksum_shortcut(self):
+        val = 0x010203
+        self.assertEqual(Hex(val, 'crc32'), Hex.crc32(val))
+        self.assertEqual(Hex(val, 'md5'), Hex.md5(val))
+        self.assertEqual(Hex(val, 'sha1'), Hex.sha1(val))
+        self.assertEqual(Hex(val, 'sha256'), Hex.sha256(val))
+
+    def test_prefix(self):
+
+        pref = '1234'
+        cases = (
+            ('crc32',  '12340000'),
+            ('md5',    '12340000000000000000000000000000'),
+            ('sha1',   '1234000000000000000000000000000000000000'),
+            ('sha256', '1234000000000000000000000000000000000000000000000000000000000000'),
+        )
+
+        for typ, expected in cases:
+            dd('typ:', typ)
+
+            c = Hex((pref, 0), typ)
+
+            self.assertEqual(expected, c)
+
+        self.assertEqual('12340101', Hex((pref, 1), 'crc32'))
+
+    def test_str_repr(self):
+        c = Hex.crc32(1)
+        self.assertEqual('00000001', str(c))
+        self.assertEqual("'00000001'", repr(c))
+
+    def test_json(self):
+        c = Hex.crc32(('0002', 0))
+        rst = utfjson.dump(c)
+        self.assertEqual('"00020000"', rst)
+        self.assertEqual(c, utfjson.load(rst))
+
+    def test_arithmetic(self):
+
+        c = Hex.crc32(5)
+
+        self.assertEqual(6,  (c+1).int)
+        self.assertEqual(10, (c*2).int)
+        self.assertEqual(2,  (c/2).int)
+        self.assertEqual(0,  (c/6).int)
+        self.assertEqual(1,  (c % 2).int)
+        self.assertEqual(25, (c**2).int)
+
+        self.assertEqual('00000006', (c+1))
+        self.assertEqual('0000000a', (c*2))
+        self.assertEqual('00000002', (c/2))
+        self.assertEqual('00000000', (c/6))
+        self.assertEqual('00000001', (c % 2))
+        self.assertEqual('00000019', (c**2))
+
+        self.assertEqual(6, (c + Hex.crc32(1)).int)
+
+        # overflow protection
+
+        self.assertEqual(0, (c-5).int)
+        self.assertEqual(0, (c-6).int)
+
+        d = Hex.crc32(('', 0xff))
+        self.assertEqual(d, d+1)
+
+    def test_arithmetic_error(self):
+
+        c = Hex.crc32(5)
+        cases = (
+            [],
+            (),
+            {},
+            'x',
+            u'我',
+        )
+
+        for inp in cases:
+            with self.assertRaises(TypeError):
+                c + inp
+            with self.assertRaises(TypeError):
+                c - inp
+            with self.assertRaises(TypeError):
+                c * inp
+            with self.assertRaises(TypeError):
+                c / inp
+            with self.assertRaises(TypeError):
+                c % inp
+            with self.assertRaises(TypeError):
+                c ** inp


### PR DESCRIPTION
感觉hex操作还挺多的. 看看能否对 @sejust phyclean的pr简化代码有帮助.

```python
from pykit.strutil import Hex

c = Hex.sha1(0)

# create a sha1 starts with '10' and fill other chars with '00'
step = Hex.sha1(('10', 0))

for i in range(16):
    print c
    c += step

0000000000000000000000000000000000000000
1000000000000000000000000000000000000000
2000000000000000000000000000000000000000
...
```

