### PR TITLE
p3json: fix p3json.tool: outfile with the same path with infile should not truncate infile

### DIFF
--- a/p3json/test/test_tool.py
+++ b/p3json/test/test_tool.py
@@ -2,9 +2,11 @@ import os
 import sys
 import textwrap
 import unittest
-import subprocess32
 from test import test_support
 from test.script_helper import assert_python_ok
+
+import subprocess32
+
 
 class TestTool(unittest.TestCase):
     data = """
@@ -37,12 +39,47 @@ class TestTool(unittest.TestCase):
     ]
     """)
 
+    expect2 = textwrap.dedent("""\
+    [
+        [
+            "blorpie"
+        ],
+        [
+            "whoops"
+        ],
+        [],
+        "d-shtaeou",
+        "d-nthiouh",
+        "i-vhbjkhnth",
+        {
+            "nifty": 87
+        },
+        {
+            "morefield": false,
+            "field": "yes"
+        }
+    ]
+    """)
+
+    def _assert_expected(self, out, linemode=False):
+        # key order in output is uncertained, try either of the possible match.
+        expected = [self.expect, self.expect2]
+        for exp in expected:
+            if linemode:
+                if out.splitlines() == exp.encode().splitlines():
+                    return
+            else:
+                if out == exp:
+                    return
+        else:
+            self.fail("out != either of expected. out: \n" + out + "\n expect:\n" + self.expect + "\n" + self.expect2)
+
     def test_stdin_stdout(self):
         proc = subprocess32.Popen(
-                (sys.executable, '-m', 'json.tool'),
-                stdin=subprocess32.PIPE, stdout=subprocess32.PIPE)
+            (sys.executable, '-m', 'pykit.p3json.tool'),
+            stdin=subprocess32.PIPE, stdout=subprocess32.PIPE)
         out, err = proc.communicate(self.data.encode())
-        self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
+        self._assert_expected(out, linemode=True)
         self.assertEqual(err, None)
 
     def _create_infile(self):
@@ -54,16 +91,31 @@ class TestTool(unittest.TestCase):
 
     def test_infile_stdout(self):
         infile = self._create_infile()
-        rc, out, err = assert_python_ok('-m', 'json.tool', infile)
-        self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
+        rc, out, err = assert_python_ok('-m', 'pykit.p3json.tool', infile)
+        self._assert_expected(out, linemode=True)
+        self.assertEqual(err, b'')
+
+        # "-" for stdout
+        rc, out, err = assert_python_ok('-m', 'pykit.p3json.tool', infile, '-')
+        self._assert_expected(out, linemode=True)
         self.assertEqual(err, b'')
 
     def test_infile_outfile(self):
         infile = self._create_infile()
         outfile = test_support.TESTFN + '.out'
-        rc, out, err = assert_python_ok('-m', 'json.tool', infile, outfile)
+        rc, out, err = assert_python_ok('-m', 'pykit.p3json.tool', infile, outfile)
         self.addCleanup(os.remove, outfile)
         with open(outfile, "r") as fp:
-            self.assertEqual(fp.read(), self.expect)
+            self._assert_expected(fp.read())
         self.assertEqual(out, b'')
         self.assertEqual(err, b'')
+
+    def test_identical_infile_outfile(self):
+
+        infile = self._create_infile()
+        outfile = infile
+        rc, out, err = assert_python_ok('-m', 'pykit.p3json.tool', infile, outfile)
+        with open(outfile, "r") as fp:
+            self._assert_expected(fp.read())
+
+        self.assertEqual((out, err), (b'', b''))

--- a/p3json/tool.py
+++ b/p3json/tool.py
@@ -2,47 +2,54 @@ r"""Command-line tool to validate and pretty-print JSON
 
 Usage::
 
-    $ echo '{"json":"obj"}' | python -m json.tool
+    $ echo '{"json":"obj"}' | python -m pykit.p3json.tool
     {
         "json": "obj"
     }
-    $ echo '{ 1.2:3.4}' | python -m json.tool
+    $ echo '{ 1.2:3.4}' | python -m pykit.p3json.tool
     Expecting property name enclosed in double quotes: line 1 column 3 (char 2)
 
 """
 import argparse
 import collections
-from pykit import p3json
 import sys
+
+from pykit import p3json
 
 
 def main():
-    prog = 'python -m json.tool'
-    description = ('A simple command line interface for json module '
+    prog = 'python -m pykit.p3json.tool'
+    description = ('A simple command line interface for p3json module '
                    'to validate and pretty-print JSON objects.')
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('infile', nargs='?', type=argparse.FileType(),
                         help='a JSON file to be validated or pretty-printed')
-    parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
+    parser.add_argument('outfile', nargs='?', default='-',
                         help='write the output of infile to outfile')
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
     options = parser.parse_args()
 
     infile = options.infile or sys.stdin
-    outfile = options.outfile or sys.stdout
     sort_keys = options.sort_keys
+
     with infile:
         try:
             if sort_keys:
-                obj = json.load(infile)
+                obj = p3json.load(infile)
             else:
-                obj = json.load(infile,
-                                object_pairs_hook=collections.OrderedDict)
+                obj = p3json.load(infile,
+                                  object_pairs_hook=collections.OrderedDict)
         except ValueError as e:
             raise SystemExit(e)
+
+    if options.outfile == '-':
+        outfile = sys.stdout
+    else:
+        outfile = open(options.outfile, 'w')
+
     with outfile:
-        json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
+        p3json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
         outfile.write('\n')
 
 


### PR DESCRIPTION
p3json: fix p3json.tool: outfile with the same path with infile should not truncate infile

Fix: #444

See: https://bugs.python.org/issue33927

`FileType` in argparse results in a instance file open:
`parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'))`.

A lot thanks to @4383 👍 