### PR TITLE
use allocated drives to make next mount index

### DIFF
--- a/ectypes/server.py
+++ b/ectypes/server.py
@@ -32,13 +32,17 @@ def _make_mountpoints_info():
 
 def _get_allocated_drive(allocated_drive_pre, mountpoints):
     rst = {}
+    max_mount_idx = 0
     for m in mountpoints:
         if not m.startswith(allocated_drive_pre):
             continue
 
         rst[m] = {'status': 'normal'}
+        idx = int(m.split('/')[-1])
 
-    return rst
+        max_mount_idx = max_mount_idx if max_mount_idx > idx else idx
+
+    return rst, max_mount_idx
 
 
 def make_serverrec(server_id, idc, idc_type, roles, allocated_drive_pre, **argkv):
@@ -68,8 +72,9 @@ def make_serverrec(server_id, idc, idc_type, roles, allocated_drive_pre, **argkv
 
     mps = _make_mountpoints_info()
     serverrec['mountpoints'] = mps
-    serverrec['next_mount_index'] = 1
-    serverrec['allocated_drive'] = _get_allocated_drive(allocated_drive_pre, mps)
+    allocated_drive, max_mount_idx = _get_allocated_drive(allocated_drive_pre, mps)
+    serverrec['next_mount_index'] = max_mount_idx + 1
+    serverrec['allocated_drive'] = allocated_drive
     serverrec.update(argkv)
 
     return serverrec


### PR DESCRIPTION
### (做了啥)

- 根据allocated drives生成next mount index

### (实现意图)

- 修复已经挂载好磁盘的机器，生成的next mount index是1的问题

Fix: #xxx
