### PR TITLE
linux always use 512 Byte as sector size

### DIFF
--- a/fsutil/iostat.py
+++ b/fsutil/iostat.py
@@ -147,12 +147,7 @@ def load_st(devname):
     else:
         raise DeviceNotFound("device not found in /proc/diskstats: " + sys_key)
 
-    sector_size = fsutil.read_file('/sys/block/{sys_key}/queue/hw_sector_size'.format(
-        sys_key=sys_key))
-
-    sector_size = int(sector_size)
-
-    st = format_dev_st(elts, sector_size)
+    st = format_dev_st(elts, 512)
     st['name'] = devname
     return st
 


### PR DESCRIPTION
### (做了啥)

- /proc/diskstats always use 512Byte as sector size 

### (实现意图)

...

Fix: #xxx
