### PR TITLE
make is_parity, is_data, is_replica as classmethod

### DIFF
--- a/ectypes/block_group.py
+++ b/ectypes/block_group.py
@@ -424,11 +424,14 @@ class BlockGroup(FixedKeysDict):
         blks = self.get_idc_blocks(idc_idx, is_del=is_del)
         return [BlockID(b['block_id']) for b in blks]
 
-    def is_data(self, block_id):
+    @classmethod
+    def is_data(cls, block_id):
         return block_id.type in ('d0', 'x0')
 
-    def is_replica(self, block_id):
+    @classmethod
+    def is_replica(cls, block_id):
         return re.match(r'd[1-9]', block_id.type) is not None
 
-    def is_parity(self, block_id):
+    @classmethod
+    def is_parity(cls, block_id):
         return block_id.type in ('dp', 'xp')

--- a/ectypes/test/test_block_group.py
+++ b/ectypes/test/test_block_group.py
@@ -624,12 +624,12 @@ class TestBlockGroup(unittest.TestCase):
 
         blks = bg.indexes_to_blocks(idxes)
 
-        self.assertTrue(bg.is_data(blks[0]['block_id']))
-        self.assertTrue(bg.is_data(blks[1]['block_id']))
-        self.assertTrue(bg.is_parity(blks[2]['block_id']))
+        self.assertTrue(BlockGroup.is_data(blks[0]['block_id']))
+        self.assertTrue(BlockGroup.is_data(blks[1]['block_id']))
+        self.assertTrue(BlockGroup.is_parity(blks[2]['block_id']))
 
-        self.assertTrue(bg.is_parity(blks[3]['block_id']))
-        self.assertTrue(bg.is_data(blks[4]['block_id']))
+        self.assertTrue(BlockGroup.is_parity(blks[3]['block_id']))
+        self.assertTrue(BlockGroup.is_data(blks[4]['block_id']))
 
-        self.assertTrue(bg.is_replica(blks[5]['block_id']))
-        self.assertTrue(bg.is_replica(blks[6]['block_id']))
+        self.assertTrue(BlockGroup.is_replica(blks[5]['block_id']))
+        self.assertTrue(BlockGroup.is_replica(blks[6]['block_id']))


### PR DESCRIPTION
### (做了啥)

- make is_parity, is_data, is_replica as classmethod

### (实现意图)
在没有BlockGroup对象的时候，也能够通过class来直接调用这些函数

Fix: #xxx
